### PR TITLE
Reset latch after each run

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,8 +1,11 @@
 .DS_Store
+bin
 build
-.eclipse
 .classpath
+.eclipse
 .gradle
+.project
+.settings
 out
 *.log
 *.i*

--- a/reactor-core/src/test/java/reactor/dispatch/DispatcherThroughputTests.java
+++ b/reactor-core/src/test/java/reactor/dispatch/DispatcherThroughputTests.java
@@ -74,14 +74,14 @@ public class DispatcherThroughputTests {
 			// pre-select everything to ensure it's in the cache
 			reactor.getConsumerRegistry().select(sels[i]);
 		}
+	}
+
+	protected void preRun() {
+		start = System.currentTimeMillis();
 		latch = new CountDownLatch(selectors * iterations);
 	}
 
-	protected void startTimer() {
-		start = System.currentTimeMillis();
-	}
-
-	protected void stopTimer() {
+	protected void postRun() {
 		end = System.currentTimeMillis();
 		elapsed = (end - start);
 		throughput = Math.round((selectors * iterations) / (elapsed / 1000));
@@ -91,12 +91,12 @@ public class DispatcherThroughputTests {
 
 	protected void doTest() throws InterruptedException {
 		for (int j = 0; j < testRuns; j++) {
-			startTimer();
+			preRun();
 			for (int i = 0; i < selectors * iterations; i++) {
 				reactor.notify(sels[i % selectors], hello);
 			}
 			latch.await(30, TimeUnit.SECONDS);
-			stopTimer();
+			postRun();
 		}
 	}
 

--- a/reactor-core/src/test/java/reactor/dispatch/LoadBalancingThroughputTests.java
+++ b/reactor-core/src/test/java/reactor/dispatch/LoadBalancingThroughputTests.java
@@ -47,13 +47,13 @@ public class LoadBalancingThroughputTests extends DispatcherThroughputTests {
 	@Override
 	protected void doTest() throws InterruptedException {
 		for (int j = 0; j < testRuns; j++) {
-			startTimer();
+			preRun();
 			for (int i = 0; i < selectors * iterations; i++) {
 				int x = (i % selectors) % 10;
 				reactor.notify(sels[x], hello);
 			}
 			latch.await(30, TimeUnit.SECONDS);
-			stopTimer();
+			postRun();
 		}
 	}
 


### PR DESCRIPTION
The throughput tests use a CountDownLatch to determine when a run
is complete. Each test performs multiple runs. Previously, the latch
was being setup once per test so for anything but the first run in the
test the latch would already be counted down.

Update the tests to reset the latch before each run.
