### PR TITLE
Parameter templates of Observable methods accepting Supplier have been improved to allow more strictly typed client code

### DIFF
--- a/reactor-core/src/main/java/reactor/core/Reactor.java
+++ b/reactor-core/src/main/java/reactor/core/Reactor.java
@@ -215,7 +215,7 @@ public class Reactor implements Observable, Linkable<Observable> {
 	}
 
 	@Override
-	public <S extends Supplier<Event<?>>> Reactor notify(Object key, S supplier) {
+	public <S extends Supplier<? extends Event<?>>> Reactor notify(Object key, S supplier) {
 		return notify(key, supplier.get(), null, eventRouter);
 	}
 
@@ -225,7 +225,7 @@ public class Reactor implements Observable, Linkable<Observable> {
 	}
 
 	@Override
-	public <S extends Supplier<Event<?>>> Reactor notify(S supplier) {
+	public <S extends Supplier<? extends Event<?>>> Reactor notify(S supplier) {
 		return notify(defaultKey, supplier.get(), null, eventRouter);
 	}
 
@@ -240,7 +240,7 @@ public class Reactor implements Observable, Linkable<Observable> {
 	}
 
 	@Override
-	public <S extends Supplier<Event<?>>> Reactor send(Object key, S supplier) {
+	public <S extends Supplier<? extends Event<?>>> Reactor send(Object key, S supplier) {
 		return notify(key, new ReplyToEvent(supplier.get(), this));
 	}
 
@@ -250,7 +250,7 @@ public class Reactor implements Observable, Linkable<Observable> {
 	}
 
 	@Override
-	public <S extends Supplier<Event<?>>> Reactor send(Object key, S supplier, Observable replyTo) {
+	public <S extends Supplier<? extends Event<?>>> Reactor send(Object key, S supplier, Observable replyTo) {
 		return notify(key, new ReplyToEvent(supplier.get(), replyTo));
 	}
 

--- a/reactor-core/src/main/java/reactor/fn/Observable.java
+++ b/reactor-core/src/main/java/reactor/fn/Observable.java
@@ -108,7 +108,7 @@ public interface Observable {
 	 *
 	 * @return {@literal this}
 	 */
-	<S extends Supplier<Event<?>>> Observable notify(Object key, S supplier);
+	<S extends Supplier<? extends Event<?>>> Observable notify(Object key, S supplier);
 
 	/**
 	 * Notify this component that an {@link Event} is ready to be processed using the internal key that is unique
@@ -134,7 +134,7 @@ public interface Observable {
 	 *
 	 * @see #on(Consumer)
 	 */
-	<S extends Supplier<Event<?>>> Observable notify(S supplier);
+	<S extends Supplier<? extends Event<?>>> Observable notify(S supplier);
 
 	/**
 	 * Notify this component of the given {@link Event} and register an internal {@link Consumer} that will take the output
@@ -159,7 +159,7 @@ public interface Observable {
 	 *
 	 * @return {@literal this}
 	 */
-	<S extends Supplier<Event<?>>> Observable send(Object key, S supplier);
+	<S extends Supplier<? extends Event<?>>> Observable send(Object key, S supplier);
 
 	/**
 	 * Notify this component of the given {@link Event} and register an internal {@link Consumer} that will take the output
@@ -187,7 +187,7 @@ public interface Observable {
 	 *
 	 * @return {@literal this}
 	 */
-	<S extends Supplier<Event<?>>> Observable send(Object key, S supplier, Observable replyTo);
+	<S extends Supplier<? extends Event<?>>> Observable send(Object key, S supplier, Observable replyTo);
 
 	/**
 	 * Notify this component that the consumers registered with a {@link Selector} that matches the {@code key} should be


### PR DESCRIPTION
It is possible to write

``` java
    reactor.notify("test", new Supplier<Event<String>>() {
        public Event<String> get() {
            return Event.wrap("Hello, world!!");
        }
    });
```

instead of 

``` java
    reactor.notify("test", new Supplier<Event<?>>() {
        public Event<?> get() {
            return Event.wrap("Hello, world!!");
        }
    });
```

now.
