### PR TITLE
RoundRobinFilter read-write lock recheck.

### DIFF
--- a/reactor-core/src/main/java/reactor/filter/RoundRobinFilter.java
+++ b/reactor-core/src/main/java/reactor/filter/RoundRobinFilter.java
@@ -63,6 +63,7 @@ public final class RoundRobinFilter extends AbstractFilter {
 				readLock.unlock();
 				writeLock.lock();
 				try {
+					usageCount = this.usageCounts.get(key);
 					if (usageCount == null) {
 						usageCount = new AtomicLong();
 						this.usageCounts.put(key, usageCount);


### PR DESCRIPTION
According to `ReentrantReadWriteLock.java` javadoc, we should

``` java
Recheck state because another thread might have
acquired write lock and changed state before we did.
```

In our case if `usageCount == null`, than `usageCounts` map doesn't contain this key. But during 

``` java
readLock.unlock();
writeLock.lock();
```

another thread can modify `usageCounts` map.
Seems like we need a recheck.
