### PR TITLE
Make sure dataSuppler and consumer are only set once.

### DIFF
--- a/reactor-core/src/main/java/reactor/core/processor/Operation.java
+++ b/reactor-core/src/main/java/reactor/core/processor/Operation.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2011-2013 GoPivotal, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package reactor.core.processor;
 
 import reactor.function.Supplier;

--- a/reactor-core/src/main/java/reactor/core/processor/Processor.java
+++ b/reactor-core/src/main/java/reactor/core/processor/Processor.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2011-2013 GoPivotal, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package reactor.core.processor;
 
 import com.lmax.disruptor.*;

--- a/reactor-core/src/main/java/reactor/core/processor/spec/ProcessorSpec.java
+++ b/reactor-core/src/main/java/reactor/core/processor/spec/ProcessorSpec.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2011-2013 GoPivotal, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package reactor.core.processor.spec;
 
 import reactor.core.processor.Processor;
@@ -6,6 +22,7 @@ import reactor.event.registry.Registry;
 import reactor.event.selector.Selectors;
 import reactor.function.Consumer;
 import reactor.function.Supplier;
+import reactor.util.Assert;
 
 /**
  * Specification class to create {@link Processor Processors}.
@@ -63,6 +80,7 @@ public class ProcessorSpec<T> implements Supplier<Processor<T>> {
 	 * @return {@literal this}
 	 */
 	public ProcessorSpec<T> dataSupplier(Supplier<T> dataSupplier) {
+    Assert.isNull(this.dataSupplier, "Data Supplier is already set.");
 		this.dataSupplier = dataSupplier;
 		return this;
 	}
@@ -77,6 +95,7 @@ public class ProcessorSpec<T> implements Supplier<Processor<T>> {
 	 * @return {@literal this}
 	 */
 	public ProcessorSpec<T> consume(Consumer<T> consumer) {
+    Assert.isNull(this.consumer, "Consumer is already set.");
 		this.consumer = consumer;
 		return this;
 	}


### PR DESCRIPTION
This changeset makes sure that on the processor spec,
the dataSupplier and the consumer are only set once.
This also makes the contract ecplicit that in the
current implementation, only one dataSupplier and
one consumer can be used.
