### PR TITLE
Adding batching capabilities to the DelegatingConsumer.

### DIFF
--- a/reactor-core/src/test/java/reactor/function/support/DelegatingConsumerTest.java
+++ b/reactor-core/src/test/java/reactor/function/support/DelegatingConsumerTest.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright (c) 2011-2013 GoPivotal, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package reactor.function.support;
+
+import org.junit.Test;
+import reactor.function.batch.BatchConsumer;
+
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+
+import static org.junit.Assert.assertTrue;
+
+/**
+ * @author Michael Nitschinger
+ */
+public class DelegatingConsumerTest {
+
+  @Test
+  public void testDelegatingBatchInformation() throws Exception {
+    DelegatingConsumer<Boolean> delegatingConsumer = new DelegatingConsumer<Boolean>();
+
+    final CountDownLatch latch = new CountDownLatch(3);
+    BatchConsumer<Boolean> batchConsumer = new BatchConsumer<Boolean>() {
+      @Override
+      public void start() {
+        latch.countDown();
+      }
+
+      @Override
+      public void end() {
+        latch.countDown();
+      }
+
+      @Override
+      public void accept(Boolean content) {
+        latch.countDown();
+      }
+    };
+
+    delegatingConsumer.add(batchConsumer);
+
+    delegatingConsumer.start();
+    delegatingConsumer.accept(true);
+    delegatingConsumer.end();
+
+    assertTrue("Batch consumer did not receive all methods", latch.await(5, TimeUnit.SECONDS));
+  }
+
+}


### PR DESCRIPTION
This change makes it possible that (optinally) BatchConsumers
can be used as delegates. They will be notified of a batch
start and end if they are, and it will be silently ignored
if they are ordinary Consumers.
