### PR TITLE
Fix reconnect logic so only successful connections are accepted

### DIFF
--- a/reactor-tcp/src/main/java/reactor/tcp/netty/NettyTcpClient.java
+++ b/reactor-tcp/src/main/java/reactor/tcp/netty/NettyTcpClient.java
@@ -257,25 +257,24 @@ public class NettyTcpClient<IN, OUT> extends TcpClient<IN, OUT> {
 							},
 							delay
 					);
-				}
-
-				if (log.isInfoEnabled()) {
-					log.info("CONNECT: " + future.channel());
-				}
-				final NettyTcpConnection<IN, OUT> conn = (NettyTcpConnection<IN, OUT>) select(future.channel());
-				future.channel().closeFuture().addListener(new ChannelFutureListener() {
-					@Override
-					public void operationComplete(ChannelFuture future) throws Exception {
-						if (log.isInfoEnabled()) {
-							log.info("CLOSED: " + future.channel());
-						}
-						NettyTcpClient.this.connections.unregister(future.channel());
-						notifyClose(conn);
-						connectionSupplier.get().addListener(self);
+				} else {
+					if (log.isInfoEnabled()) {
+						log.info("CONNECT: " + future.channel());
 					}
-				});
-
-				connections.accept(conn);
+					final NettyTcpConnection<IN, OUT> conn = (NettyTcpConnection<IN, OUT>) select(future.channel());
+					future.channel().closeFuture().addListener(new ChannelFutureListener() {
+						@Override
+						public void operationComplete(ChannelFuture future) throws Exception {
+							if (log.isInfoEnabled()) {
+								log.info("CLOSED: " + future.channel());
+							}
+							NettyTcpClient.this.connections.unregister(future.channel());
+							notifyClose(conn);
+							connectionSupplier.get().addListener(self);
+						}
+					});
+					connections.accept(conn);
+				}
 			}
 		};
 	}


### PR DESCRIPTION
NettyTcpClient.createReconnectListener currently accepts a connection
regardless of whether or not it connected successfully. This leads to
the Consumer<TcpConnection> registered with the Stream being driven
multiple times with TcpConnections that are not connected.

This commit updates NettyTcpClient.createReconnectListener so that
only successful connections are accepted.

Fixes #162
