### PR TITLE
Improve TcpClient's close behaviour

### DIFF
--- a/reactor-tcp/src/main/java/reactor/tcp/netty/NettyTcpClient.java
+++ b/reactor-tcp/src/main/java/reactor/tcp/netty/NettyTcpClient.java
@@ -73,6 +73,7 @@ public class NettyTcpClient<IN, OUT> extends TcpClient<IN, OUT> {
 	private final    EventLoopGroup          ioGroup;
 	private final    Supplier<ChannelFuture> connectionSupplier;
 	private volatile InetSocketAddress       connectAddress;
+	private volatile boolean                 closing;
 
 	/**
 	 * Creates a new NettyTcpClient that will use the given {@code env} for configuration and the given {@code reactor} to
@@ -128,7 +129,11 @@ public class NettyTcpClient<IN, OUT> extends TcpClient<IN, OUT> {
 		this.connectionSupplier = new Supplier<ChannelFuture>() {
 			@Override
 			public ChannelFuture get() {
-				return bootstrap.connect(NettyTcpClient.this.connectAddress);
+				if (!closing) {
+					return bootstrap.connect(NettyTcpClient.this.connectAddress);
+				} else {
+					return null;
+				}
 			}
 		};
 	}
@@ -140,7 +145,7 @@ public class NettyTcpClient<IN, OUT> extends TcpClient<IN, OUT> {
 																																																 .dispatcher(eventsReactor.getDispatcher())
 																																																 .get();
 
-		connectionSupplier.get().addListener(createConnectListener(connection));
+		createConnection(createConnectListener(connection));
 
 		return connection.compose();
 	}
@@ -151,8 +156,7 @@ public class NettyTcpClient<IN, OUT> extends TcpClient<IN, OUT> {
 																																																.env(env)
 																																																.dispatcher(eventsReactor.getDispatcher())
 																																																.get();
-
-		connectionSupplier.get().addListener(createReconnectListener(connections, reconnect));
+		createConnection(createReconnectListener(connections, reconnect));
 
 		return connections.compose();
 	}
@@ -187,6 +191,7 @@ public class NettyTcpClient<IN, OUT> extends TcpClient<IN, OUT> {
 	@Override
 	@SuppressWarnings({"rawtypes", "unchecked"})
 	protected void doClose(final Deferred<Void, Promise<Void>> d) {
+		this.closing = true;
 		try {
 			final CountDownLatch latch = new CountDownLatch(1);
 			this.ioGroup.shutdownGracefully().addListener(new GenericFutureListener() {
@@ -269,7 +274,7 @@ public class NettyTcpClient<IN, OUT> extends TcpClient<IN, OUT> {
 							new TimerTask() {
 								@Override
 								public void run() {
-									connectionSupplier.get().addListener(self);
+									createConnection(self);
 								}
 							},
 							delay
@@ -287,7 +292,9 @@ public class NettyTcpClient<IN, OUT> extends TcpClient<IN, OUT> {
 							}
 							NettyTcpClient.this.connections.unregister(future.channel());
 							notifyClose(conn);
-							connectionSupplier.get().addListener(self);
+							if (!conn.isClosing()) {
+								createConnection(self);
+							}
 						}
 					});
 					// hopefully avoid a race condition with user code currently assigning handlers
@@ -303,6 +310,13 @@ public class NettyTcpClient<IN, OUT> extends TcpClient<IN, OUT> {
 				}
 			}
 		};
+	}
+
+	private void createConnection(ChannelFutureListener listener) {
+		ChannelFuture channel = connectionSupplier.get();
+		if (channel != null) {
+			channel.addListener(listener);
+		}
 	}
 
 }

--- a/reactor-tcp/src/main/java/reactor/tcp/netty/NettyTcpConnection.java
+++ b/reactor-tcp/src/main/java/reactor/tcp/netty/NettyTcpConnection.java
@@ -47,6 +47,7 @@ public class NettyTcpConnection<IN, OUT> extends AbstractTcpConnection<IN, OUT> 
 
 	private volatile SocketChannel     channel;
 	private volatile InetSocketAddress remoteAddress;
+	private volatile boolean           closing = false;
 
 	NettyTcpConnection(final Environment env,
 										 Codec<Buffer, IN, OUT> codec,
@@ -84,6 +85,7 @@ public class NettyTcpConnection<IN, OUT> extends AbstractTcpConnection<IN, OUT> 
 	@Override
 	public void close() {
 		super.close();
+		closing = true;
 		try {
 			channel.close().await();
 		} catch (InterruptedException e) {
@@ -104,6 +106,10 @@ public class NettyTcpConnection<IN, OUT> extends AbstractTcpConnection<IN, OUT> 
 	@Override
 	public InetSocketAddress remoteAddress() {
 		return remoteAddress;
+	}
+
+	boolean isClosing() {
+		return closing;
 	}
 
 	void notifyRead(Object obj) {


### PR DESCRIPTION
There are a couple of problems with TcpClient's close behaviour that are addressed by these commits:
1. When TcpClient.close() is called, it would attempt to close all of its connections twice. This could cause exceptions to be thrown and the close processing to stall.
2. When a connection had been opened with a Reconnect instance, a reconnection attempt would be made even if the connection or the whole client was being closed. This could cause exceptions to be thrown, cluttering up the logs.
