### PR TITLE
First sketch of extracted map/reduce operations

### DIFF
--- a/reactor-core/src/main/java/reactor/core/composable/Composable.java
+++ b/reactor-core/src/main/java/reactor/core/composable/Composable.java
@@ -100,7 +100,7 @@ public abstract class Composable<T> {
 	 *
 	 * @return {@literal this}
 	 */
-	public Composable<T> consume(@Nonnull final Consumer<T> consumer) {
+  public Composable<T> consume(@Nonnull final Consumer<T> consumer) {
 		this.events.on(accept.getT1(), new EventConsumer<T>(consumer));
 		return this;
 	}
@@ -164,11 +164,11 @@ public abstract class Composable<T> {
 	 */
 	public <V> Composable<V> map(@Nonnull final Function<T, V> fn) {
 		Assert.notNull(fn, "Map function cannot be null.");
-		final Deferred<V, ? extends Composable<V>> d = createDeferred();
-
-    MapConsumer<T, V> mapConsumer = new MapConsumer<T, V>(d, fn);
-    this.events.on(accept.getT1(), mapConsumer);
-    return mapConsumer.getChildStream();
+    final Deferred<V, Composable<V>> d = createDeferred();
+    final Composable<V> c = d.compose();
+    MapConsumer<T, V> mapConsumer = new MapConsumer<T, V>(c.getObservable(), c.getAccept().getT2(), fn);
+    this.consumeEvent(mapConsumer);
+    return c;
 	}
 
 	/**
@@ -273,7 +273,7 @@ public abstract class Composable<T> {
 		lock.lock();
 		try {
 			acceptCount++;
-			valueAccepted(value.getData());
+      valueAccepted(value.getData());
 		} finally {
 			lock.unlock();
 		}

--- a/reactor-core/src/main/java/reactor/core/composable/Stream.java
+++ b/reactor-core/src/main/java/reactor/core/composable/Stream.java
@@ -91,7 +91,7 @@ public class Stream<T> extends Composable<T> {
 	 */
 	public Stream(@Nonnull Dispatcher dispatcher,
 	              int batchSize,
-	              @Nullable Iterable<T> values,
+                @Nullable Iterable<T> values,
 	              @Nullable Composable<?> parent) {
 		super(dispatcher, parent);
 		this.batchSize = batchSize;
@@ -164,7 +164,7 @@ public class Stream<T> extends Composable<T> {
 	 */
 	public Stream<T> first() {
 		Deferred<T, Stream<T>> d = createDeferredChildStream();
-		getObservable().on(first.getT1(), new EventConsumer<T>(d));
+    getObservable().on(first.getT1(), new EventConsumer<T>(d));
 		return d.compose();
 	}
 
@@ -178,7 +178,7 @@ public class Stream<T> extends Composable<T> {
 	 */
 	public Stream<T> last() {
 		Deferred<T, Stream<T>> d = createDeferredChildStream();
-		getObservable().on(last.getT1(), new EventConsumer<T>(d));
+    getObservable().on(last.getT1(), new EventConsumer<T>(d));
 		return d.compose();
 	}
 
@@ -301,11 +301,15 @@ public class Stream<T> extends Composable<T> {
 	 */
 	public <A> Stream<A> reduce(@Nonnull final Function<Tuple2<T, A>, A> fn, @Nullable final Supplier<A> accumulators) {
 		final Deferred<A, Stream<A>> d = createDeferred();
+    final Composable<A> c = d.compose();
 
-    ReduceConsumer reduceConsumer = new ReduceConsumer(d, fn, accumulators, this.batchSize);
+    ReduceConsumer reduceConsumer = new ReduceConsumer(c.getObservable(),
+                                                       c.getAccept().getT2(),
+                                                       fn,
+                                                       accumulators,
+                                                       this.batchSize);
     this.consumeEvent(reduceConsumer);
-    return reduceConsumer.getChildStream();
-
+    return (Stream<A>) c;
 	}
 
 	/**


### PR DESCRIPTION
Problem with Reduce is that currently it's bound to batch and operates on Stream, but not Composable, which makes it all a bit more difficult to compose.

Is it possible to (maybe) move all stream operations (`map`, `reduce`, `filter`, which are currently on `Composable`) to `Stream`, this way `Composable` will hold the event routing logic and `Stream` will be a powerful entrypoint for all stream operations. 

Please share your thoughts, it's a very critical point for us to solve that problem. Of course we can roll out everything in our private infrastructure, but we don't really want to build project based on hacks. Also we believe that our use-case is quite general for stream processing, and many people would try to repeat what we're trying to do now: to create custom streams that work with window operations, listen to several upstreams and so on.

Things like `batch` and `collect` can be moved to their own classes and reused, too. Also, this kind of "convention" brings consistency and maintains spirit of `Tap`, which stores the last value, except for Tap doesn't have to have a downstream, so is a bit different in terms of implementation.

Hope that could be helpful for Reactor project too!
