### PR TITLE
Simplify state and locking of Promise and Composable

### DIFF
--- a/reactor-core/src/main/java/reactor/core/composable/Composable.java
+++ b/reactor-core/src/main/java/reactor/core/composable/Composable.java
@@ -56,8 +56,8 @@ public abstract class Composable<T> {
 	private final Observable    events;
 	private final Composable<?> parent;
 
-	private volatile long acceptCount = 0l;
-	private volatile long errorCount  = 0l;
+	private long acceptCount = 0l;
+	private long errorCount  = 0l;
 
 	protected <U> Composable(
 			@Nonnull Dispatcher dispatcher,

--- a/reactor-core/src/test/groovy/reactor/core/composable/spec/PromisesSpec.groovy
+++ b/reactor-core/src/test/groovy/reactor/core/composable/spec/PromisesSpec.groovy
@@ -247,6 +247,22 @@ class PromisesSpec extends Specification {
       value == 'test'
   }
 
+  def "A promise can be fulfilled with null"() {
+    given:
+      "a promise"
+      def deferred = Promises.<Object> defer().get()
+      def promise = deferred.compose()
+
+    when:
+      "the promise is fulfilled with null"
+      deferred.accept null
+
+    then:
+      "the promise was successful"
+      promise.isComplete()
+      promise.isSuccess()
+  }
+
   def "An Observable can be used to consume a promise's value when it's fulfilled"() {
     given:
       "a promise with a consuming Observable"


### PR DESCRIPTION
This commit addresses the problems detailed in issue #191. It removes
Promise's monitor, and, instead, uses the ReentrantLock from its
superclass, Composable.

The state field has been removed from Promise. This field represented
a duplicate of the state held in the error and value fields and
introduced the risk of bugs causing this state to get out of sync. The
Promise's state is now always determined by looking at the value and
error fields:

```
Both error and value being null means the promise is pending
Error being non-null means the promise failed
Value being non-null means the promise succeeded
Both error and value being non-null is prohibited
```

The use of hasBlockers has been moved so that it's always read and
written when locked. This should eliminate the possibility of
notifications being missed.

Fields that are always accessed under a lock are no longer declared
volatile.
