### PR TITLE
Make sure that the onComplete promise is only accepted once.

### DIFF
--- a/reactor-tcp/src/main/java/reactor/tcp/netty/NettyTcpConnection.java
+++ b/reactor-tcp/src/main/java/reactor/tcp/netty/NettyTcpConnection.java
@@ -136,16 +136,16 @@ public class NettyTcpConnection<IN, OUT> extends AbstractTcpConnection<IN, OUT> 
 			public void operationComplete(ChannelFuture future) throws Exception {
 				boolean success = future.isSuccess();
 
-				if(!success) {
+				if (success) {
+					if (onComplete != null) {
+						onComplete.accept(success);
+					}
+				} else {
 					Throwable t = future.cause();
 					eventsReactor.notify(t, Event.wrap(t));
-					if(null != onComplete) {
+					if (onComplete != null) {
 						onComplete.accept(t);
 					}
-				}
-
-				if(null != onComplete) {
-					onComplete.accept(success);
 				}
 			}
 		});


### PR DESCRIPTION
This prevents the case that if success is false, the promise
is tried to be accepted twice, therefore raising an exception
inside the netty eventloop.
