### PR TITLE
Fix ./gradlew eclipse

### DIFF
--- a/gradle/ide.gradle
+++ b/gradle/ide.gradle
@@ -36,7 +36,7 @@ eclipse.classpath.file.whenMerged { classpath ->
 eclipse.classpath.defaultOutputDir = file(project.name + "/bin/eclipse")
 eclipse.classpath.file.beforeMerged { classpath ->
 	classpath.entries.findAll { it instanceof SourceFolder }.each {
-		if (it.output.startsWith("bin/")) {
+		if (it.output?.startsWith("bin/")) {
 			it.output = null
 		}
 	}


### PR DESCRIPTION
Running ./gradlew eclipse was failing due to ide.gradle assuming that
SourceFolder's will always have an output. Apparently, this isn't
the case.

This commit makes ide.gradle a little more defensive by using Groovy's
safe navigation to cope with a null output on a SourceFolder.
