### PR TITLE
reactore-core: Expose the deleage on the ReplyToConsumer.

### DIFF
--- a/reactor-core/src/main/java/reactor/core/Reactor.java
+++ b/reactor-core/src/main/java/reactor/core/Reactor.java
@@ -353,7 +353,7 @@ public class Reactor implements Observable, Linkable<Observable> {
 		}
 	}
 
-	private class ReplyToConsumer<E extends Event<?>, V> implements Consumer<E> {
+	public class ReplyToConsumer<E extends Event<?>, V> implements Consumer<E> {
 		private final Function<E, V> fn;
 
 		private ReplyToConsumer(Function<E, V> fn) {
@@ -385,6 +385,10 @@ public class Reactor implements Observable, Linkable<Observable> {
 			} catch(Throwable x) {
 				replyToObservable.notify(x.getClass(), Event.wrap(x));
 			}
+		}
+
+		public Function<E, V> getDelegate() {
+			return fn;
 		}
 	}
 


### PR DESCRIPTION
Exposing the delegate allows to get a reference to the enclosed
function after it has been added. This enables use-cases like
cancelling the registration and then calling a method on the
function (like shutdown).
