### PR TITLE
Make selectors generic, accepting Matcher type and Matching Object type

### DIFF
--- a/reactor-core/src/main/java/reactor/core/dynamic/reflect/SimpleMethodSelectorResolver.java
+++ b/reactor-core/src/main/java/reactor/core/dynamic/reflect/SimpleMethodSelectorResolver.java
@@ -44,7 +44,7 @@ public class SimpleMethodSelectorResolver implements MethodSelectorResolver {
 			sel = methodNameToSelectorName(method.getName());
 		}
 
-		return (!"".equals(sel) ? new ObjectSelector<String>(sel) : null);
+		return (!"".equals(sel) ? new ObjectSelector<String, String>(sel) : null);
 	}
 
 	@Override

--- a/reactor-core/src/main/java/reactor/event/selector/ClassSelector.java
+++ b/reactor-core/src/main/java/reactor/event/selector/ClassSelector.java
@@ -24,7 +24,7 @@ package reactor.event.selector;
  * @author Andy Wilkinson
  * @author Stephane Maldini
  */
-public class ClassSelector extends ObjectSelector<Class<?>> {
+public class ClassSelector extends ObjectSelector<Class<?>, Object> {
 
 	/**
 	 * Creates a new ClassSelector that will match keys that are the same as, or are a

--- a/reactor-core/src/main/java/reactor/event/selector/JsonPathSelector.java
+++ b/reactor-core/src/main/java/reactor/event/selector/JsonPathSelector.java
@@ -25,7 +25,7 @@ import java.util.*;
 /**
  * @author Jon Brisbin
  */
-public class JsonPathSelector extends ObjectSelector<JsonPath> {
+public class JsonPathSelector extends ObjectSelector<JsonPath, Object> {
 
 	// Only need one of these
 	private static ObjectMapper MAPPER = new ObjectMapper();

--- a/reactor-core/src/main/java/reactor/event/selector/ObjectSelector.java
+++ b/reactor-core/src/main/java/reactor/event/selector/ObjectSelector.java
@@ -29,12 +29,12 @@ import java.util.*;
  * @author Jon Brisbin
  * @author Andy Wilkinson
  */
-public class ObjectSelector<T> implements Selector {
+public class ObjectSelector<M, T> implements Selector<M, T> {
 
 	private final UUID   uuid    = UUIDUtils.create();
 	private final Object monitor = new Object();
 
-	private final T                 object;
+	private final M                 object;
 	private       SortedSet<String> tags;
 
 	/**
@@ -42,7 +42,7 @@ public class ObjectSelector<T> implements Selector {
 	 *
 	 * @param object The object to wrap.
 	 */
-	public ObjectSelector(T object) {
+	public ObjectSelector(M object) {
 		this.object = object;
 	}
 
@@ -53,8 +53,8 @@ public class ObjectSelector<T> implements Selector {
 	 * @param <T> The type of the object.
 	 * @return The new {@link Selector}.
 	 */
-	public static <T> Selector objectSelector(T obj) {
-		return new ObjectSelector<T>(obj);
+	public static <M, T> Selector objectSelector(M obj) {
+		return new ObjectSelector<M, T>(obj);
 	}
 
 	@Override
@@ -63,12 +63,12 @@ public class ObjectSelector<T> implements Selector {
 	}
 
 	@Override
-	public T getObject() {
+	public M getObject() {
 		return object;
 	}
 
 	@Override
-	public boolean matches(Object key) {
+	public boolean matches(T key) {
 		return !(null == object && null != key) && (object != null && object.equals(key));
 	}
 
@@ -79,7 +79,7 @@ public class ObjectSelector<T> implements Selector {
 
 	@Override
 	protected Object clone() throws CloneNotSupportedException {
-		return new ObjectSelector<T>(object);
+    return new ObjectSelector<M, T>(object);
 	}
 
 	@Override

--- a/reactor-core/src/main/java/reactor/event/selector/PredicateSelector.java
+++ b/reactor-core/src/main/java/reactor/event/selector/PredicateSelector.java
@@ -7,7 +7,7 @@ import reactor.function.Predicate;
  *
  * @author Jon Brisbin
  */
-public class PredicateSelector extends ObjectSelector<Predicate<Object>> {
+public class PredicateSelector<T> extends ObjectSelector<Predicate<Object>,T> {
 
 	public PredicateSelector(Predicate<Object> object) {
 		super(object);

--- a/reactor-core/src/main/java/reactor/event/selector/RegexSelector.java
+++ b/reactor-core/src/main/java/reactor/event/selector/RegexSelector.java
@@ -37,7 +37,7 @@ import java.util.regex.Pattern;
  * @author Jon Brisbin
  * @author Andy Wilkinson
  */
-public class RegexSelector extends ObjectSelector<Pattern> {
+public class RegexSelector extends ObjectSelector<Pattern, String> {
 
 	private final HeaderResolver headerResolver = new HeaderResolver() {
 		@Nullable
@@ -81,9 +81,8 @@ public class RegexSelector extends ObjectSelector<Pattern> {
 	}
 
 	@Override
-	public boolean matches(Object key) {
-		return key instanceof String
-				&& getObject().matcher((String)key).matches();
+	public boolean matches(String key) {
+		return getObject().matcher(key).matches();
 	}
 
 	@Override

--- a/reactor-core/src/main/java/reactor/event/selector/Selector.java
+++ b/reactor-core/src/main/java/reactor/event/selector/Selector.java
@@ -25,7 +25,7 @@ import java.util.UUID;
  * @author Stephane Maldini
  * @author Andy Wilkinson
  */
-public interface Selector  {
+public interface Selector<M, T>  {
 
 	/**
 	 * Get the unique id of this Selector
@@ -39,7 +39,7 @@ public interface Selector  {
 	 *
 	 * @return The internal object.
 	 */
-	Object getObject();
+  M getObject();
 
 	/**
 	 * Indicates whether this Selector matches the {@code key}.
@@ -48,7 +48,7 @@ public interface Selector  {
 	 *
 	 * @return {@code true} if there's a match, otherwise {@code false}.
 	 */
-	boolean matches(Object key);
+	boolean matches(T key);
 
 	/**
 	 * Return a component that can resolve headers from a key

--- a/reactor-core/src/main/java/reactor/event/selector/Selectors.java
+++ b/reactor-core/src/main/java/reactor/event/selector/Selectors.java
@@ -49,7 +49,7 @@ public abstract class Selectors {
 	 * @see ObjectSelector
 	 */
 	public static <T> Selector object(T obj) {
-		return new ObjectSelector<T>(obj);
+		return new ObjectSelector<T, T>(obj);
 	}
 
 	/**

--- a/reactor-core/src/main/java/reactor/event/selector/UriTemplateSelector.java
+++ b/reactor-core/src/main/java/reactor/event/selector/UriTemplateSelector.java
@@ -27,7 +27,7 @@ import java.util.Map;
  *
  * @see UriTemplate
  */
-public class UriTemplateSelector extends ObjectSelector<UriTemplate> {
+public class UriTemplateSelector extends ObjectSelector<UriTemplate, String> {
 
 	private final HeaderResolver headerResolver = new HeaderResolver() {
 		@Nullable
@@ -64,13 +64,8 @@ public class UriTemplateSelector extends ObjectSelector<UriTemplate> {
 	}
 
 	@Override
-	public boolean matches(Object key) {
-		if (!(key instanceof String)) {
-			return false;
-		}
-
-		String path = (String) key;
-		return getObject().matches(path);
+	public boolean matches(String key) {
+    return getObject().matches(key);
 	}
 
 	@Override

--- a/reactor-core/src/test/groovy/reactor/GroovyTestUtils.java
+++ b/reactor-core/src/test/groovy/reactor/GroovyTestUtils.java
@@ -33,15 +33,15 @@ public abstract class GroovyTestUtils {
 	}
 
 	public static Selector $(long l) {
-		return new ObjectSelector<Long>(l);
+		return new ObjectSelector<Long, Long>(l);
 	}
 
 	public static Selector $(String s) {
-		return new ObjectSelector<String>(s);
+		return new ObjectSelector<String, String>(s);
 	}
 
 	public static Selector $(GString s) {
-		return new ObjectSelector<String>(s.toString());
+		return new ObjectSelector<String, String>(s.toString());
 	}
 
 	@SuppressWarnings({"rawtypes"})

--- a/reactor-spring/src/main/java/reactor/spring/event/selector/ExpressionSelector.java
+++ b/reactor-spring/src/main/java/reactor/spring/event/selector/ExpressionSelector.java
@@ -14,7 +14,7 @@ import reactor.event.selector.Selector;
  *
  * @author Jon Brisbin
  */
-public class ExpressionSelector extends ObjectSelector<Expression> {
+public class ExpressionSelector extends ObjectSelector<Expression, Object> {
 
 	private static final SpelExpressionParser SPEL_PARSER = new SpelExpressionParser();
 
@@ -27,7 +27,7 @@ public class ExpressionSelector extends ObjectSelector<Expression> {
 
 	@Override
 	public boolean matches(Object key) {
-		return getObject().getValue(evalCtx, key, Boolean.class);
+    return getObject().getValue(evalCtx, key, Boolean.class);
 	}
 
 	/**


### PR DESCRIPTION
This allows to write selectors that are aware of the Matcher type,
and Matching Object type, that will take Matcher and check wether
or not Matching Object is an appropriate match.

This eliminates type checks and casts for the most used use-cases
such as same-type-object selectors:

In case with simple object selector it will be:

     new ObjectSelector<T, T>(obj);

Which means that objects with different types won't be matched.

Regular Expression selector now accepts a Pattern and String, and
there's no need to cast object back to String.