### PR TITLE
Tests for TcpClient <--> TcpServer interactions

### DIFF
--- a/reactor-tcp/src/test/groovy/reactor/tcp/netty/ClientServerIntegrationSpec.groovy
+++ b/reactor-tcp/src/test/groovy/reactor/tcp/netty/ClientServerIntegrationSpec.groovy
@@ -1,0 +1,167 @@
+/*
+ * Copyright (c) 2011-2013 GoPivotal, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package reactor.tcp.netty
+
+import reactor.core.Environment
+import reactor.function.Consumer
+import reactor.io.encoding.json.JsonCodec
+import reactor.tcp.TcpConnection
+import reactor.tcp.spec.TcpClientSpec
+import reactor.tcp.spec.TcpServerSpec
+import reactor.tcp.support.SocketUtils
+import spock.lang.Specification
+import spock.lang.Unroll
+
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.TimeUnit
+
+class ClientServerIntegrationSpec extends Specification {
+
+    Environment env
+
+    def setup() {
+        env = new Environment()
+    }
+
+    @Unroll
+    def "Client should be able to send data to server"(List<Pojo> data) {
+        given: "a TcpServer and TcpClient with JSON codec"
+        def startLatch = new CountDownLatch(2)
+        def stopLatch = new CountDownLatch(2)
+        def dataLatch = new CountDownLatch(data.size())
+
+        final int port = SocketUtils.findAvailableTcpPort()
+
+        def consumerMock = Mock(Consumer) { data.size() * accept(_) }
+
+        def server = new TcpServerSpec<Pojo, Pojo>(NettyTcpServer)
+                .env(env)
+                .listen(port)
+                .codec(new JsonCodec<Pojo, Pojo>(Pojo))
+                .consume({ conn ->
+                    conn.in().consume({ pojo ->
+                        dataLatch.countDown()
+                        consumerMock.accept(pojo)
+                    } as Consumer<Pojo>)
+                } as Consumer<TcpConnection<Pojo, Pojo>>)
+                .get()
+
+        def client = new TcpClientSpec<Pojo, Pojo>(NettyTcpClient)
+                .env(env)
+                .codec(new JsonCodec<Pojo, Pojo>(Pojo))
+                .connect("localhost", port)
+                .get()
+
+        when: 'the server is started'
+        server.start({startLatch.countDown()} as Consumer<Void>)
+        startLatch.await(5, TimeUnit.SECONDS)
+
+        and: "connection is established"
+        def connectionPromise = client.open()
+        startLatch.countDown()
+        def connection = connectionPromise.await()
+
+        and: "pojo is written"
+        data.each { Pojo item -> connection.sendAndForget(item) }
+        [dataLatch, startLatch].each {it.await(5, TimeUnit.SECONDS)}
+
+        then: "everything went fine"
+        startLatch.count == 0
+        dataLatch.count == 0
+
+        when: "server and client are stopped"
+        client.close().onSuccess({stopLatch.countDown()} as Consumer<Void>)
+        server.shutdown().onSuccess({stopLatch.countDown() } as Consumer<Void>)
+        stopLatch.await(5, TimeUnit.SECONDS)
+
+        then: "everything is really stopped"
+        stopLatch.count == 0
+
+        where:
+            data << [
+                    [new Pojo('John')],
+                    [new Pojo('John'), new Pojo("Jane")],
+                    [new Pojo('John'), new Pojo("Jane"), new Pojo("Blah")],
+                    [1..10].collect {new Pojo("Value_$it")}.toList(),
+            ]
+    }
+
+    @Unroll
+    def "Server should be able to send POJO to client"(List<Pojo> data) {
+        given: "a TcpServer and TcpClient with JSON codec"
+        def startLatch = new CountDownLatch(1)
+        def stopLatch = new CountDownLatch(2)
+        def dataLatch = new CountDownLatch(data.size())
+
+        final int port = SocketUtils.findAvailableTcpPort()
+
+        def consumerMock = Mock(Consumer) { 1 * accept(_) }
+
+        def server = new TcpServerSpec<Pojo, Pojo>(NettyTcpServer)
+                .env(env)
+                .listen(port)
+                .codec(new JsonCodec<Pojo, Pojo>(Pojo))
+                .consume({ conn -> data.each{pojo -> conn.out().accept(pojo)}} as Consumer)
+                .get()
+
+        def client = new TcpClientSpec<Pojo, Pojo>(NettyTcpClient)
+                .env(env)
+                .codec(new JsonCodec<Pojo, Pojo>(Pojo))
+                .connect("localhost", port)
+                .get()
+
+        when: 'the server is started'
+        server.start({ startLatch.countDown() } as Consumer<Void>)
+        startLatch.await(5, TimeUnit.SECONDS)
+
+        and: "connection is established"
+        client.open().consume({ TcpConnection conn ->
+            conn.consume({ Pojo pojo -> consumerMock.accept(pojo); dataLatch.countDown()} as Consumer)
+            startLatch.countDown()
+        } as Consumer).await()
+
+        and: "data is being sent"
+        [dataLatch, startLatch].each { it.await(5, TimeUnit.SECONDS) }
+
+        then: "everything went fine"
+        startLatch.count == 0
+        dataLatch.count == 0
+
+        when: "server and client are stopped"
+        client.close().onSuccess({ stopLatch.countDown() } as Consumer<Void>)
+        server.shutdown().onSuccess({ stopLatch.countDown() } as Consumer<Void>)
+        stopLatch.await(5, TimeUnit.SECONDS)
+
+        then: "everything is really stopped"
+        stopLatch.count == 0
+
+        where:
+        data << [
+                [new Pojo('John')],
+                [new Pojo('John'), new Pojo("Jane")],
+                [new Pojo('John'), new Pojo("Jane"), new Pojo("Blah")],
+                [1..10].collect {new Pojo("Value_$it")}.toList(),
+        ]
+    }
+
+    static class Pojo {
+        public Pojo(){}
+        public Pojo(String name) {this.name = name}
+        String name
+    }
+
+}


### PR DESCRIPTION
Hi everyone! :)

Here are some spock tests with data-driven structure. I wrote them to help to fix #248.

If you run them, there can be seen that TcpClient +TcpServer interaction cannot sustain number of messages other than 2. I mean, this Spec is now failing.

So, I assume, with #248 fixed, these tests should check that it is really fixed :)

Thanks :-D
