### PR TITLE
fix #254 Refactor Streams.defer(value) and Streams.defer(values) 

### DIFF
--- a/reactor-core/src/main/java/reactor/core/composable/spec/Streams.java
+++ b/reactor-core/src/main/java/reactor/core/composable/spec/Streams.java
@@ -123,8 +123,8 @@ public abstract class Streams {
 	 * @return a {@link DeferredStreamSpec} based on the given value
 	 */
 	@SuppressWarnings("unchecked")
-	public static <T> DeferredStreamSpec<T> defer(T value) {
-		return defer(Arrays.asList(value));
+	public static <T> StreamSpec<T> defer(T value) {
+		return  new StreamSpec<T>().each(Arrays.asList(value)).batchSize(1);
 	}
 
 	/**
@@ -138,11 +138,11 @@ public abstract class Streams {
 	 * @param <T>
 	 * 		type of the values
 	 *
-	 * @return a {@link DeferredStreamSpec} based on the given values
+	 * @return a {@link StreamSpec} based on the given values
 	 */
-	public static <T> DeferredStreamSpec<T> defer(Iterable<T> values) {
+	public static <T> StreamSpec<T> defer(Iterable<T> values) {
 		int batchSize = (values instanceof Collection ? ((Collection<?>)values).size() : -1);
-		return new DeferredStreamSpec<T>().each(values).batchSize(batchSize);
+		return new StreamSpec<T>().each(values).batchSize(batchSize);
 	}
 
 }

--- a/reactor-core/src/test/java/reactor/core/composable/ComposableTests.java
+++ b/reactor-core/src/test/java/reactor/core/composable/ComposableTests.java
@@ -57,9 +57,9 @@ public class ComposableTests extends AbstractReactorTest {
 
 	@Test
 	public void testComposeFromSingleValue() throws InterruptedException {
-		Deferred<String, Stream<String>> d = Streams.defer("Hello World!").get();
+		Stream<String> stream = Streams.defer("Hello World!").get();
 		Stream<String> s =
-				d.compose()
+				stream
 				 .map(new Function<String, String>() {
 					 @Override
 					 public String apply(String s) {
@@ -72,9 +72,9 @@ public class ComposableTests extends AbstractReactorTest {
 
 	@Test
 	public void testComposeFromMultipleValues() throws InterruptedException {
-		Deferred<String, Stream<String>> d = Streams.defer(Arrays.asList("1", "2", "3", "4", "5")).get();
+		Stream<String> stream = Streams.defer(Arrays.asList("1", "2", "3", "4", "5")).get();
 		Stream<Integer> s =
-				d.compose()
+				stream
 				 .map(STRING_2_INTEGER)
 				 .map(new Function<Integer, Integer>() {
 					 int sum = 0;
@@ -90,9 +90,9 @@ public class ComposableTests extends AbstractReactorTest {
 
 	@Test
 	public void testComposeFromMultipleFilteredValues() throws InterruptedException {
-		Deferred<String, Stream<String>> d = Streams.defer(Arrays.asList("1", "2", "3", "4", "5")).get();
+		Stream<String> stream = Streams.defer(Arrays.asList("1", "2", "3", "4", "5")).get();
 		Stream<Integer> s =
-				d.compose()
+				stream
 				 .map(STRING_2_INTEGER)
 				 .filter(new Predicate<Integer>() {
 					 @Override
@@ -107,7 +107,7 @@ public class ComposableTests extends AbstractReactorTest {
 
 	@Test
 	public void testComposedErrorHandlingWithMultipleValues() throws InterruptedException {
-		Deferred<String, Stream<String>> d =
+		Stream<String> stream =
 				Streams.defer(Arrays.asList("1", "2", "3", "4", "5"))
 				       .env(env)
 				       .dispatcher("eventLoop")
@@ -115,7 +115,7 @@ public class ComposableTests extends AbstractReactorTest {
 
 		final AtomicBoolean exception = new AtomicBoolean(false);
 		Stream<Integer> s =
-				d.compose()
+				stream
 				 .map(STRING_2_INTEGER)
 				 .when(IllegalArgumentException.class, new Consumer<IllegalArgumentException>() {
 					 @Override
@@ -142,9 +142,9 @@ public class ComposableTests extends AbstractReactorTest {
 
 	@Test
 	public void testReduce() throws InterruptedException {
-		Deferred<String, Stream<String>> d = Streams.defer(Arrays.asList("1", "2", "3", "4", "5")).get();
+		Stream<String> stream = Streams.defer(Arrays.asList("1", "2", "3", "4", "5")).get();
 		Stream<Integer> s =
-				d.compose()
+				stream
 				 .map(STRING_2_INTEGER)
 				 .reduce(new Function<Tuple2<Integer, Integer>, Integer>() {
 					 @Override
@@ -157,9 +157,9 @@ public class ComposableTests extends AbstractReactorTest {
 
 	@Test
 	public void testFirstAndLast() throws InterruptedException {
-		Deferred<String, Stream<String>> d = Streams.defer(Arrays.asList("1", "2", "3", "4", "5")).get();
+		Stream<String> stream = Streams.defer(Arrays.asList("1", "2", "3", "4", "5")).get();
 		Stream<Integer> s =
-				d.compose()
+				stream
 				 .map(STRING_2_INTEGER);
 
 		Tap<Integer> first = s.first().tap();
@@ -184,9 +184,9 @@ public class ComposableTests extends AbstractReactorTest {
 			}
 		});
 
-		Deferred<String, Stream<String>> d = Streams.defer(Arrays.asList("1", "2", "3", "4", "5")).get();
+		Stream<String> stream = Streams.defer(Arrays.asList("1", "2", "3", "4", "5")).get();
 		Stream<Integer> s =
-				d.compose()
+				stream
 				 .map(STRING_2_INTEGER)
 				 .consume(key.getObject(), r);
 		Tap<Integer> tap = s.tap();
@@ -200,9 +200,9 @@ public class ComposableTests extends AbstractReactorTest {
 
 	@Test
 	public void testStreamBatchesResults() {
-		Deferred<String, Stream<String>> d = Streams.defer(Arrays.asList("1", "2", "3", "4", "5")).get();
+		Stream<String> stream = Streams.defer(Arrays.asList("1", "2", "3", "4", "5")).get();
 		Stream<List<Integer>> s =
-				d.compose()
+				stream
 				 .map(STRING_2_INTEGER)
 				 .collect();
 
@@ -224,10 +224,10 @@ public class ComposableTests extends AbstractReactorTest {
 
 	@Test
 	public void testHandlersErrorsDownstream() throws InterruptedException {
-		Deferred<String, Stream<String>> d = Streams.defer(Arrays.asList("1", "2", "a", "4", "5")).get();
+		Stream<String> stream = Streams.defer(Arrays.asList("1", "2", "a", "4", "5")).get();
 		final CountDownLatch latch = new CountDownLatch(1);
 		Stream<Integer> s =
-				d.compose()
+				stream
 				 .map(STRING_2_INTEGER)
 				 .map(new Function<Integer, Integer>() {
 					 int sum = 0;

--- a/reactor-groovy/src/test/groovy/reactor/groovy/GroovyStreamSpec.groovy
+++ b/reactor-groovy/src/test/groovy/reactor/groovy/GroovyStreamSpec.groovy
@@ -47,12 +47,12 @@ class GroovyStreamSpec extends Specification {
 	def "Compose from multiple values"() {
 		when:
 			'Defer a composition'
-			Deferred c = Streams.defer(['1', '2', '3', '4', '5']).get()
+			Stream s = Streams.defer(['1', '2', '3', '4', '5']).get()
 
 		and:
 			'apply a transformation'
 			int sum = 0
-			Stream d = c | { Integer.parseInt it } | { sum += it; sum }
+			Stream d = s | { Integer.parseInt it } | { sum += it; sum }
 
 		then:
 			d.flush()
@@ -207,7 +207,7 @@ class GroovyStreamSpec extends Specification {
 
 		and:
 			'Defer a composition'
-			Deferred c = Streams.defer(['1', '2', '3', '4', '5']).get()
+			Stream c = Streams.defer(['1', '2', '3', '4', '5']).get()
 
 		and:
 			'apply a transformation and call an explicit reactor'


### PR DESCRIPTION
Now these methods return a Stream rather than a Deferred, thus preventing fixed streams to be confused with Streams.defer()
