### PR TITLE
Add Event Allocator

### DIFF
--- a/reactor-core/src/main/java/reactor/core/Reactor.java
+++ b/reactor-core/src/main/java/reactor/core/Reactor.java
@@ -294,7 +294,7 @@ public class Reactor implements Observable {
 
 	@Override
 	public Reactor notify(Object key) {
-		return notify(key, new Event<Void>(null), null);
+		return notify(key, new Event<Void>(Void.class), null);
 	}
 
 	@Override
@@ -420,7 +420,7 @@ public class Reactor implements Observable {
 
 				Event<?> replyEv;
 				if(null == reply) {
-					replyEv = new Event<Void>(null);
+					replyEv = new Event<Void>(Void.class);
 				} else {
 					replyEv = (Event.class.isAssignableFrom(reply.getClass()) ? (Event<?>)reply : Event.wrap(reply));
 				}

--- a/reactor-core/src/main/java/reactor/core/alloc/EventAllocator.java
+++ b/reactor-core/src/main/java/reactor/core/alloc/EventAllocator.java
@@ -1,0 +1,78 @@
+package reactor.core.alloc;
+
+import reactor.core.alloc.factory.EventFactorySupplier;
+import reactor.event.Event;
+
+import java.util.HashMap;
+
+/**
+ * Generic Event Allocator. Allocates events based on their generic type.
+ *
+ * @author Oleksandr Petrov
+ */
+public abstract class EventAllocator {
+
+  private final Object                     monitor;
+  private final HashMap<Class, Allocator>  eventPools;
+
+  public EventAllocator() {
+    this(new Class[0]);
+  }
+
+  /**
+   * Create a new {@link reactor.core.alloc.EventAllocator}, containing pre-created
+   * {@link reactor.core.alloc.Allocator}s for given {@data class}es.
+   *
+   * @param classes
+   */
+  public EventAllocator(Class[] classes) {
+    this.eventPools = new HashMap<Class, Allocator>();
+    this.monitor = new Object();
+    for(Class c: classes) {
+      eventPools.put(c, makeAllocator(c));
+    }
+  }
+
+  /**
+   * Allocate an object from the internal pool, based on the type of Event.
+   *
+   * @param klass generic type of {@link reactor.event.Event}
+   * @param <T> generic type of {@link reactor.event.Event}
+   *
+   * @return a {@link reactor.core.alloc.Reference} that can be retained and released.
+   */
+  public <T> Reference<Event<T>> get(Class<T> klass) {
+    if(!eventPools.containsKey(klass)) {
+      synchronized (monitor) {
+        // Check once again if another thread didn't create a supplier in a meanwhile
+        if(!eventPools.containsKey(klass)) {
+          eventPools.put(klass, makeAllocator(klass));
+        }
+      }
+    }
+    return eventPools.get(klass).allocate();
+  }
+
+  /**
+   * Make a new allocator for {@link reactor.event.Event}s with generic type of {@data klass}
+   *
+   * @param klass generic type of {@link reactor.event.Event}
+   * @param <T> generic type of {@link reactor.event.Event}
+   */
+  protected abstract <T> Allocator<Event<T>> makeAllocator(Class<T> klass);
+
+  /**
+   * Default Event Allocator, uses {@link reactor.core.alloc.ReferenceCountingAllocator} for
+   * allocating and recycling events.
+   *
+   * @return newly constructed event alloator.
+   */
+  public static EventAllocator defaultEventAllocator() {
+    return new EventAllocator() {
+      @Override
+      protected <T> Allocator<Event<T>> makeAllocator(Class<T> klass) {
+        return new ReferenceCountingAllocator<Event<T>>(new EventFactorySupplier(klass));
+      }
+    };
+  }
+}

--- a/reactor-core/src/main/java/reactor/core/alloc/factory/EventFactorySupplier.java
+++ b/reactor-core/src/main/java/reactor/core/alloc/factory/EventFactorySupplier.java
@@ -1,0 +1,26 @@
+package reactor.core.alloc.factory;
+
+import reactor.event.Event;
+import reactor.function.Supplier;
+
+/**
+ * A {@link reactor.function.Supplier} implementation that instantiates Events
+ * based on Event data type.
+ *
+ * @param <T> type of {@link reactor.event.Event} data
+ * @author Oleksandr Petrov
+ * @since 1.1
+ */
+public class EventFactorySupplier<T> implements Supplier<Event<T>> {
+
+  private final Class<T> klass;
+
+  public EventFactorySupplier(Class<T> klass) {
+    this.klass = klass;
+  }
+
+  @Override
+  public Event<T> get() {
+    return new Event<T>(klass);
+  }
+}

--- a/reactor-core/src/main/java/reactor/core/composable/Composable.java
+++ b/reactor-core/src/main/java/reactor/core/composable/Composable.java
@@ -286,7 +286,7 @@ public abstract class Composable<T> implements Pipeline<T> {
 	 * Notify this {@code Composable} hat a flush is being requested by this {@code Composable}.
 	 */
 	void notifyFlush() {
-		events.notify(flush.getObject(), new Event<Void>(null));
+		events.notify(flush.getObject(), new Event<Void>(Void.class));
 	}
 
 	/**

--- a/reactor-core/src/main/java/reactor/event/Event.java
+++ b/reactor-core/src/main/java/reactor/event/Event.java
@@ -48,7 +48,18 @@ public class Event<T> implements Serializable, Recyclable {
 
 	private final transient Consumer<Throwable> errorConsumer;
 
-	/**
+  /**
+   * Creates a new Event based on the type T of {@data data}
+   *
+   * @param klass
+   */
+  public Event(Class<T> klass) {
+    this.headers = null;
+    this.data = null;
+    this.errorConsumer = null;
+  }
+
+  /**
 	 * Creates a new Event with the given {@code headers} and {@code data}.
 	 *
 	 * @param headers

--- a/reactor-core/src/test/java/reactor/core/alloc/EventAllocatorTests.java
+++ b/reactor-core/src/test/java/reactor/core/alloc/EventAllocatorTests.java
@@ -1,0 +1,23 @@
+package reactor.core.alloc;
+
+import org.junit.Test;
+import reactor.event.Event;
+
+import static junit.framework.Assert.assertTrue;
+
+public class EventAllocatorTests {
+
+  @Test
+  public void eventAllocatorTest() {
+    EventAllocator eventAllocator = EventAllocator.defaultEventAllocator();
+
+    Event<String> eStr = eventAllocator.get(String.class).get();
+    eStr.setData("string");
+    assertTrue("String data is settable into the String event", eStr.getData() == "string");
+
+
+    Event<Integer> eInt = eventAllocator.get(Integer.class).get();
+    eInt.setData(1);
+    assertTrue("Integer data is settable into the Integer event", eInt.getData() == 1);
+  }
+}


### PR DESCRIPTION
Currently only Task objects are pooled. After profiling our application, we've found
GC contention related to Event objects, which were generated at high rates, and
causing long GC pauses every 5-6 seconds.

Polling Event objects helped us to avoid it. In combination with Task object pooling
(especially well seen on RingBufferDispatcher), Event object pooling will significantly
improve a memory snapshot and provide many possibilities for flexible object
creation / reuse.

As per conversation with Jon, we agreed that we'll provide an unobtrusive way to
allocate events based on generic interface and recycle them as needed, but will
not provide it as a default, since it may make quite difficult for people just wanting
to start working with project as soon as possible to figure out potential resource
leaks.

This is a simple, "reference" implementation of Event Allocator.
