### PR TITLE
fix #284

### DIFF
--- a/reactor-core/src/main/java/reactor/core/action/ActionUtils.java
+++ b/reactor-core/src/main/java/reactor/core/action/ActionUtils.java
@@ -125,10 +125,6 @@ public abstract class ActionUtils {
 		private void renderBatch(Object consumer, int d) {
 			if (BatchAction.class.isAssignableFrom(consumer.getClass())) {
 				BatchAction operation = (BatchAction) consumer;
-				appender.append(" accepted:" + operation.getAcceptCount());
-				appender.append("|errors:" + operation.getErrorCount());
-				appender.append("|batchSize:" + operation.getBatchSize());
-
 				loopRegistredActions(((Reactor) operation.getObservable()).getConsumerRegistry().select(operation.getFirstKey()),
 						d + 1, "first");
 				loopRegistredActions(((Reactor) operation.getObservable()).getConsumerRegistry().select(operation.getFlushKey()),

--- a/reactor-core/src/main/java/reactor/core/action/FlushableAction.java
+++ b/reactor-core/src/main/java/reactor/core/action/FlushableAction.java
@@ -22,11 +22,11 @@ import reactor.event.Event;
  * @author Stephane Maldini
  * @since 1.1
  */
-public class FlushableAction<T> extends Action<Void> {
+public class FlushableAction extends Action<Void> {
 
-	private final Flushable<T> flushable;
+	private final Flushable<?> flushable;
 
-	public FlushableAction(Flushable<T> flushable, Observable d, Object failureKey) {
+	public FlushableAction(Flushable<?> flushable, Observable d, Object failureKey) {
 		super(d, null, failureKey);
 		this.flushable = flushable;
 	}

--- a/reactor-core/src/main/java/reactor/core/action/MapManyAction.java
+++ b/reactor-core/src/main/java/reactor/core/action/MapManyAction.java
@@ -24,14 +24,15 @@ import reactor.function.Function;
  * @author Jon Brisbin
  * @since 1.1
  */
-public class MapManyAction<T, V, E extends Pipeline<V>> extends Action<T> {
+public class MapManyAction<T, V, E extends Pipeline<V>> extends Action<T>{
 
 	private final Function<T, E> fn;
 
 	public MapManyAction(Function<T, E> fn,
 	                     Observable ob,
 	                     Object successKey,
-	                     Object failureKey) {
+	                     Object failureKey
+	                     ) {
 		super(ob, successKey, failureKey);
 		this.fn = fn;
 	}

--- a/reactor-core/src/main/java/reactor/core/action/Pipeline.java
+++ b/reactor-core/src/main/java/reactor/core/action/Pipeline.java
@@ -16,7 +16,8 @@
 package reactor.core.action;
 
 /**
- * Component that can be injected with {@link Action}s
+ * Component that can be injected with {@link Action}s and consume flush events for releasing buffer owned by the
+ * pipeline
  *
  * @author Stephane Maldini
  * @author Jon Brisbin
@@ -32,4 +33,14 @@ public interface Pipeline<T> extends Flushable<T>{
 	 */
 	Pipeline<T> add(Action<T> action);
 
+
+	/**
+	 * Consume flush with the passed {@link Flushable}
+	 *
+	 * @param action
+	 * 		the action listening for flush
+	 *
+	 * @return {@literal this}
+	 */
+	Pipeline<T> consumeFlush(Flushable<?> action);
 }

--- a/reactor-core/src/main/java/reactor/core/composable/Stream.java
+++ b/reactor-core/src/main/java/reactor/core/composable/Stream.java
@@ -163,8 +163,8 @@ public class Stream<T> extends Composable<T> {
 	}
 
 	@Override
-	public Stream<T> consume(@Nonnull Composable<T> composable) {
-		return (Stream<T>) super.consume(composable);
+	public Stream<T> connectValues(@Nonnull Composable<T> composable) {
+		return (Stream<T>) super.connectValues(composable);
 	}
 
 	@Override
@@ -178,7 +178,12 @@ public class Stream<T> extends Composable<T> {
 	}
 
 	@Override
-	public Stream<T> consumeFlush(@Nonnull Flushable<T> consumer) {
+	public Stream<T> merge(Composable<T>... composables) {
+		return (Stream<T>) super.merge(composables);
+	}
+
+	@Override
+	public Stream<T> consumeFlush(@Nonnull Flushable<?> consumer) {
 		return (Stream<T>) super.consumeFlush(consumer);
 	}
 
@@ -200,20 +205,9 @@ public class Stream<T> extends Composable<T> {
 		return this;
 	}
 
-	/**
-	 * Create a new {@code Stream} whose values will be generated from {@param supplier}.
-	 * Every time flush is triggered, {@param supplier} is called.
-	 *
-	 * @param supplier the supplier to drain
-	 * @return a new {@code Stream} whose values are generated on each flush
-	 * @since 1.1
-	 */
+	@Override
 	public Stream<T> propagate(Supplier<T> supplier) {
-		consumeFlush(new SupplyAction<T>(supplier,
-				getObservable(),
-				getAcceptKey(),
-				getError().getObject()));
-		return this;
+		return (Stream<T>)super.propagate(supplier);
 	}
 
 	/**
@@ -389,10 +383,10 @@ public class Stream<T> extends Composable<T> {
 	 * every time {@code
 	 * batchSize} has been reached. All errors are also captured until current batchSize or flush is called.
 	 *
-	 * @return a new {@code Stream} whose values are a {@link List} of all values in this batch
+	 * @return a new {@code Stream} whose values of all values in this batch
 	 * @since 1.1
 	 */
-	public Stream<List<T>> bufferWithErrors() {
+	public Stream<T> bufferWithErrors() {
 		return bufferWithErrors(batchSize);
 	}
 
@@ -402,11 +396,11 @@ public class Stream<T> extends Composable<T> {
 	 * batchSize} has been reached. All errors are also captured until batchSize or flush is called.
 	 *
 	 * @param batchSize the collected size
-	 * @return a new {@code Stream} whose values are a {@link List} of all values in this batch
+	 * @return a new {@code Stream} whose values are all values in this batch
 	 * @since 1.1
 	 */
-	public Stream<List<T>> bufferWithErrors(int batchSize) {
-		final Deferred<List<T>, Stream<List<T>>> d = createDeferred(1);
+	public Stream<T> bufferWithErrors(int batchSize) {
+		final Deferred<T, Stream<T>> d = createDeferred(batchSize);
 
 		add(new BufferAction<T>(batchSize,
 				d.compose().getObservable(),

--- a/reactor-core/src/main/java/reactor/core/composable/spec/ComposableSpec.java
+++ b/reactor-core/src/main/java/reactor/core/composable/spec/ComposableSpec.java
@@ -42,6 +42,7 @@ public abstract class ComposableSpec<SPEC extends ComposableSpec<SPEC, TARGET>, 
 	 *
 	 * @param acceptSelector The selector tuple to listen/publish to
 	 * @return {@code this}
+	 * @since 1.1
 	 */
 	@SuppressWarnings("unchecked")
 	SPEC acceptSelector(final Tuple2<Selector, Object> acceptSelector) {
@@ -54,6 +55,7 @@ public abstract class ComposableSpec<SPEC extends ComposableSpec<SPEC, TARGET>, 
 	 *
 	 * @param observable The observable to listen/publish to
 	 * @return {@code this}
+	 * @since 1.1
 	 */
 	@SuppressWarnings("unchecked")
 	SPEC observable(final Observable observable) {

--- a/reactor-core/src/main/java/reactor/core/composable/spec/PromiseSpec.java
+++ b/reactor-core/src/main/java/reactor/core/composable/spec/PromiseSpec.java
@@ -86,7 +86,7 @@ public final class PromiseSpec<T> extends ComposableSpec<PromiseSpec<T>, Promise
 		if (value != null) {
 			return new Promise<T>(value, observable, env);
 		} else if (valueSupplier != null) {
-			return new Promise<T>(valueSupplier, observable, env);
+			return new Promise<T>(observable, env, null).propagate(valueSupplier);
 		} else if (error != null) {
 			return new Promise<T>(error, observable, env);
 		} else {

--- a/reactor-core/src/main/java/reactor/core/composable/spec/Promises.java
+++ b/reactor-core/src/main/java/reactor/core/composable/spec/Promises.java
@@ -196,7 +196,7 @@ public abstract class Promises {
 				.get()
 				.compose();
 
-		aggregatedStream.consume(resultPromise);
+		aggregatedStream.connectValues(resultPromise);
 
 		for(Promise<T> promise : promises) {
 			promise.connect(deferredStream);

--- a/reactor-core/src/test/groovy/reactor/core/composable/spec/PromisesSpec.groovy
+++ b/reactor-core/src/test/groovy/reactor/core/composable/spec/PromisesSpec.groovy
@@ -311,6 +311,22 @@ class PromisesSpec extends Specification {
       mappedPromise.get() == 2
   }
 
+  def "A map many can be used to bind to another Promise and compose asynchronous results "() {
+    given:
+      "a promise with a map many function"
+      def deferred = Promises.<Integer> defer().get()
+      def promise = deferred.compose()
+      def mappedPromise = promise.mapMany(function { Promises.success(it+1).get() })
+
+    when:
+      "the original promise is fulfilled"
+      deferred.accept 1
+
+    then:
+      "the mapped promise is fulfilled with the mapped value"
+      mappedPromise.get() == 2
+  }
+
   def "A function can be used to map an already-fulfilled Promise's value"() {
     given:
       "a fulfilled promise with a mapping function"
@@ -657,7 +673,7 @@ class PromisesSpec extends Specification {
 
 	  then:
       "it is rejected"
-	    thrown RuntimeException
+		  thrown RuntimeException
       promise.error
   }
 


### PR DESCRIPTION
add Composable#merge to connect N composable to the current pipeline
explicit consume name from consume(Composable) to connectValues(Composable)  : values forwarded; to be inline with connect(Composable) : error and values forwarded.
Add a promise.mapMany test
Promote consumeFlush to Pipeline
Fix promise flush cascading
Remove Flushable generic type constraint
