### PR TITLE
Fixes #298  reinstate remoteAddress()

### DIFF
--- a/reactor-net/src/main/java/reactor/net/NetChannel.java
+++ b/reactor-net/src/main/java/reactor/net/NetChannel.java
@@ -6,12 +6,21 @@ import reactor.function.Consumer;
 import reactor.function.Function;
 import reactor.function.batch.BatchConsumer;
 
+import java.net.InetSocketAddress;
+
 /**
  * {@code NetChannel} implementations handle interacting with the client.
  *
  * @author Jon Brisbin
  */
 public interface NetChannel<IN, OUT> {
+
+	/**
+	 * Get the address of the remote peer.
+	 *
+	 * @return the peer's address
+	 */
+	InetSocketAddress remoteAddress();
 
 	/**
 	 * {@link reactor.core.composable.Stream} of incoming decoded data.

--- a/reactor-net/src/main/java/reactor/net/netty/NettyNetChannel.java
+++ b/reactor-net/src/main/java/reactor/net/netty/NettyNetChannel.java
@@ -22,6 +22,7 @@ import reactor.net.AbstractNetChannel;
 
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
+import java.net.InetSocketAddress;
 import java.nio.ByteBuffer;
 import java.util.concurrent.TimeUnit;
 
@@ -47,6 +48,11 @@ public class NettyNetChannel<IN, OUT> extends AbstractNetChannel<IN, OUT> {
 
 	public boolean isClosing() {
 		return closing;
+	}
+
+	@Override
+	public InetSocketAddress remoteAddress() {
+		return (InetSocketAddress)ioChannel.remoteAddress();
 	}
 
 	@Override


### PR DESCRIPTION
Add `remoteAddress()` method to `NetChannel`. Also added a test to ensure the information is populated.

/cc @pidster
