### PR TITLE
IncludeCallerData so that, for example, line numbers are passed along wh...

### DIFF
--- a/reactor-logback/src/main/java/reactor/logback/AsyncAppender.java
+++ b/reactor-logback/src/main/java/reactor/logback/AsyncAppender.java
@@ -59,6 +59,8 @@ public class AsyncAppender
 	private Processor<LogEvent> processor;
 	private Thread              publisher;
 
+	private boolean		    includeCallerData;
+
 	@Override public String getName() {
 		return name;
 	}
@@ -154,6 +156,11 @@ public class AsyncAppender
 		}
 
 		ev.prepareForDeferredProcessing();
+
+                if(includeCallerData) {
+                    ev.getCallerData();
+                }
+
 		publishQueue.add(ev);
 	}
 
@@ -208,6 +215,14 @@ public class AsyncAppender
 	@Override public boolean detachAppender(String name) {
 		return aai.detachAppender(name);
 	}
+
+        public boolean isIncludeCallerData() {
+                return includeCallerData;
+        }
+
+        public void setIncludeCallerData(final boolean includeCallerData) {
+                this.includeCallerData = includeCallerData;
+        }
 
 	private static class LogEvent {
 		ILoggingEvent event;


### PR DESCRIPTION
IncludeCallerData so that, for example, line numbers are passed along whenever
a logging event occurs. To use, ensure that in your logback configuration you
have something similar to:

```
<appender name="..." class="reactor.logback.AsyncAppender">
    <appender-ref ref="..."/>
    <includeCallerData>true</includeCallerData>
<appender>
```

-=david=-

p.s., my SpringSource contributor number is: 18120120105024518.
