### PR TITLE
Fix for uninformative exception being thrown from Environment.getDispatcher()

### DIFF
--- a/reactor-core/src/main/java/reactor/core/Environment.java
+++ b/reactor-core/src/main/java/reactor/core/Environment.java
@@ -253,9 +253,12 @@ public class Environment implements Iterable<Map.Entry<String, List<Dispatcher>>
 	 */
 	public Dispatcher getDispatcher(String name) {
 		synchronized(monitor) {
-			List<Dispatcher> dispatchers = this.dispatchers.get(name);
-			List<Dispatcher> filteredDispatchers = this.dispatcherFilter.filter(dispatchers, name);
-			if(filteredDispatchers.isEmpty()) {
+            List<Dispatcher> filteredDispatchers = Collections.emptyList();
+            List<Dispatcher> dispatchers = this.dispatchers.get(name);
+            if (dispatchers != null) {
+                filteredDispatchers = this.dispatcherFilter.filter(dispatchers, name);
+            }
+            if(filteredDispatchers.isEmpty()) {
 				throw new IllegalArgumentException("No Dispatcher found for name '" + name + "'");
 			} else {
 				return filteredDispatchers.get(0);

--- a/reactor-core/src/test/java/reactor/core/EnvironmentTest.java
+++ b/reactor-core/src/test/java/reactor/core/EnvironmentTest.java
@@ -1,0 +1,21 @@
+package reactor.core;
+
+import org.junit.Test;
+import reactor.AbstractReactorTest;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.fail;
+
+public class EnvironmentTest extends AbstractReactorTest {
+
+    @Test
+    public void testGetDispatcherThrowsExceptionWhenNoDispatcherIsFound() throws Exception {
+        try {
+            env.getDispatcher("NonexistingDispatcher");
+            fail("Should have thrown an exception");
+        } catch ( IllegalArgumentException e ) {
+            assertEquals("No Dispatcher found for name 'NonexistingDispatcher'", e.getMessage());
+        }
+    }
+
+}


### PR DESCRIPTION
Fix for uninformative exception being thrown when no dispatcher is
registered with particular name. Previously internal exception from
AbstractFilter was propagated to clients making identifying of issues
quite complicated.
