### PR TITLE
Make configuration of Spring IO plugin less invasive

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -170,10 +170,16 @@ if (JavaVersion.current().isJava8Compatible()) {
 }
 
 configure(subprojects) { subproject ->
-	apply plugin: 'spring-io'
+	if (project.hasProperty('platformVersion')) {
+		apply plugin: 'spring-io'
 
-	dependencies {
-		springIoVersions 'io.spring.platform:platform-versions:1.0.0.BUILD-SNAPSHOT@properties'
+		repositories {
+			maven { url 'http://repo.spring.io/libs-snapshot' }
+		}
+
+		dependencies {
+			springIoVersions "io.spring.platform:platform-versions:$platformVersion@properties"
+		}
 	}
 
 	test {


### PR DESCRIPTION
The plugin is now only applied when the build is run with the platformVersion property. This property is also used to determine the version of the platform-versions dependency that will be used by the springIoCheck task. This breaks a circular dependency between the projects that are included in the Platform and the Platform itself.
