### PR TITLE
Fix #294: Thread-safe HashMap to avoid faulty Consumer notifications

### DIFF
--- a/reactor-core/src/main/java/reactor/event/dispatch/AbstractMultiThreadDispatcher.java
+++ b/reactor-core/src/main/java/reactor/event/dispatch/AbstractMultiThreadDispatcher.java
@@ -4,10 +4,12 @@ import reactor.alloc.factory.BatchFactorySupplier;
 import reactor.function.Supplier;
 
 import java.util.ArrayList;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.atomic.AtomicInteger;
+ 
+import com.gs.collections.impl.map.mutable.SynchronizedMutableMap;
+import com.gs.collections.impl.map.mutable.UnifiedMap;
 
 /**
  * Base implementation for multi-threaded dispatchers
@@ -25,8 +27,8 @@ public abstract class AbstractMultiThreadDispatcher extends AbstractLifecycleDis
 	private final List<List<Task>>                      tailRecursionPileList;
 	private final BatchFactorySupplier<MultiThreadTask> taskFactory;
 
-	private final Map<Long, Integer> tailsThreadIndexLookup = new HashMap<Long, Integer>();
-	private final AtomicInteger         indexAssignPile        = new AtomicInteger();
+	private final Map<Long, Integer> tailsThreadIndexLookup		= SynchronizedMutableMap.of(UnifiedMap.<Long, Integer>newMap());
+	private final AtomicInteger         indexAssignPile        	= new AtomicInteger();
 
 	protected AbstractMultiThreadDispatcher(int numberThreads, int backlog) {
 		this.backlog = backlog;


### PR DESCRIPTION
When events are published on a multi-threaded dispatcher (e.g. workQueue or threadPoolExecutor)
by internal worker threads as
for example in the following configuration: `d.compose().map(..).consume(..)`
the end consumer sometimes gets duplicate notifications and sometimes no
notification at all.
The reason is most probably a non-threadsafe call to HashMap.put() which causes
same tailsThreadIndexLookup indexes being assigned to the different worker threads.
