### PR TITLE
Added Promises heterogeneous when

### DIFF
--- a/reactor-core/src/main/java/reactor/core/composable/spec/Promises.java
+++ b/reactor-core/src/main/java/reactor/core/composable/spec/Promises.java
@@ -25,8 +25,20 @@ import reactor.core.composable.Promise;
 import reactor.core.composable.Stream;
 import reactor.event.dispatch.Dispatcher;
 import reactor.function.Consumer;
+import reactor.function.Function;
 import reactor.function.Supplier;
+import reactor.tuple.Tuple;
+import reactor.tuple.Tuple2;
+import reactor.tuple.Tuple3;
+import reactor.tuple.Tuple4;
+import reactor.tuple.Tuple5;
+import reactor.tuple.Tuple6;
+import reactor.tuple.Tuple7;
+import reactor.tuple.Tuple8;
+import reactor.tuple.TupleN;
 
+import java.lang.Object;
+import java.lang.Override;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
@@ -145,7 +157,229 @@ public abstract class Promises {
 		return new PromiseSpec<T>().error(error);
 	}
 
-	/**
+
+    /**
+     * Merge given promises into a new a {@literal Promise} that will be fulfilled when all of the given {@literal Promise
+     * Promises} have been fulfilled.
+     *
+     * @param p1, p2
+     * 		The promises to use.
+     * @param <T1,T2>
+     * 		The type of the function Tuple result.
+     *
+     * @return a {@link Promise}.
+     */
+    @SuppressWarnings("unchecked")
+    public static <T1,T2> Promise<Tuple2<T1,T2>> heterogeneousWhen(Promise<T1> p1, Promise<T2> p2) {
+        Promise<Object> untypedP1 = untypedPromise(p1);
+        Promise<Object> untypedP2 = untypedPromise(p2);
+
+        return when(untypedP1, untypedP2).map(new Function<List<Object>, Tuple2<T1,T2>>() {
+            @Override
+            public Tuple2<T1,T2> apply(List<Object> objects) {
+                return Tuple.of((T1) objects.get(0), (T2) objects.get(1));
+            }
+        });
+    }
+
+    /**
+     * Merge given promises into a new a {@literal Promise} that will be fulfilled when all of the given {@literal Promise
+     * Promises} have been fulfilled.
+     *
+     * @param p1, p2, p3
+     * 		The promises to use.
+     * @param <T1,T2,T3>
+     * 		The type of the function Tuple result.
+     *
+     * @return a {@link Promise}.
+     */
+    @SuppressWarnings("unchecked")
+    public static <T1,T2,T3> Promise<Tuple3<T1,T2,T3>> heterogeneousWhen(Promise<T1> p1, Promise<T2> p2, Promise<T3> p3) {
+        Promise<Object> untypedP1 = untypedPromise(p1);
+        Promise<Object> untypedP2 = untypedPromise(p2);
+        Promise<Object> untypedP3 = untypedPromise(p3);
+
+        return Promises.when(untypedP1, untypedP2, untypedP3).map(new Function<List<Object>, Tuple3<T1,T2,T3>>() {
+            @Override
+            public Tuple3<T1,T2,T3> apply(List<Object> objects) {
+                return Tuple.of((T1) objects.get(0), (T2) objects.get(1), (T3) objects.get(2));
+            }
+        });
+    }
+
+    /**
+     * Merge given promises into a new a {@literal Promise} that will be fulfilled when all of the given {@literal Promise
+     * Promises} have been fulfilled.
+     *
+     * @param p1, p2, p3, p4
+     * 		The promises to use.
+     * @param <T1,T2,T3,T4>
+     * 		The type of the function Tuple result.
+     *
+     * @return a {@link Promise}.
+     */
+    @SuppressWarnings("unchecked")
+    public static <T1,T2,T3,T4> Promise<Tuple4<T1,T2,T3,T4>> heterogeneousWhen(Promise<T1> p1, Promise<T2> p2, Promise<T3> p3, Promise<T4> p4) {
+        Promise<Object> untypedP1 = untypedPromise(p1);
+        Promise<Object> untypedP2 = untypedPromise(p2);
+        Promise<Object> untypedP3 = untypedPromise(p3);
+        Promise<Object> untypedP4 = untypedPromise(p4);
+
+        return Promises.when(untypedP1, untypedP2, untypedP3, untypedP4).map(new Function<List<Object>, Tuple4<T1,T2,T3,T4>>() {
+            @Override
+            public Tuple4<T1,T2,T3,T4> apply(List<Object> objects) {
+                return Tuple.of((T1) objects.get(0), (T2) objects.get(1), (T3) objects.get(2), (T4) objects.get(3));
+            }
+        });
+    }
+
+    /**
+     * Merge given promises into a new a {@literal Promise} that will be fulfilled when all of the given {@literal Promise
+     * Promises} have been fulfilled.
+     *
+     * @param p1, p2, p3, p4, p5
+     * 		The promises to use.
+     * @param <T1,T2,T3,T4,T5>
+     * 		The type of the function Tuple result.
+     *
+     * @return a {@link Promise}.
+     */
+    @SuppressWarnings("unchecked")
+    public static <T1,T2,T3,T4,T5> Promise<Tuple5<T1,T2,T3,T4,T5>> heterogeneousWhen(Promise<T1> p1, Promise<T2> p2, Promise<T3> p3, Promise<T4> p4, Promise<T5> p5) {
+        Promise<Object> untypedP1 = untypedPromise(p1);
+        Promise<Object> untypedP2 = untypedPromise(p2);
+        Promise<Object> untypedP3 = untypedPromise(p3);
+        Promise<Object> untypedP4 = untypedPromise(p4);
+        Promise<Object> untypedP5 = untypedPromise(p5);
+
+        return Promises.when(untypedP1, untypedP2, untypedP3, untypedP4, untypedP5).map(new Function<List<Object>, Tuple5<T1,T2,T3,T4,T5>>() {
+            @Override
+            public Tuple5<T1,T2,T3,T4,T5> apply(List<Object> objects) {
+                return Tuple.of((T1) objects.get(0), (T2) objects.get(1), (T3) objects.get(2), (T4) objects.get(3), (T5) objects.get(4));
+            }
+        });
+    }
+
+    /**
+     * Merge given promises into a new a {@literal Promise} that will be fulfilled when all of the given {@literal Promise
+     * Promises} have been fulfilled.
+     *
+     * @param p1, p2, p3, p4, p5, p6
+     * 		The promises to use.
+     * @param <T1,T2,T3,T4,T5,T6>
+     * 		The type of the function Tuple result.
+     *
+     * @return a {@link Promise}.
+     */
+    @SuppressWarnings("unchecked")
+    public static <T1,T2,T3,T4,T5,T6> Promise<Tuple6<T1,T2,T3,T4,T5,T6>> heterogeneousWhen(Promise<T1> p1, Promise<T2> p2, Promise<T3> p3, Promise<T4> p4, Promise<T5> p5, Promise<T6> p6) {
+        Promise<Object> untypedP1 = untypedPromise(p1);
+        Promise<Object> untypedP2 = untypedPromise(p2);
+        Promise<Object> untypedP3 = untypedPromise(p3);
+        Promise<Object> untypedP4 = untypedPromise(p4);
+        Promise<Object> untypedP5 = untypedPromise(p5);
+        Promise<Object> untypedP6 = untypedPromise(p6);
+
+        return Promises.when(untypedP1, untypedP2, untypedP3, untypedP4, untypedP5, untypedP6).map(new Function<List<Object>, Tuple6<T1,T2,T3,T4,T5,T6>>() {
+            @Override
+            public Tuple6<T1,T2,T3,T4,T5,T6> apply(List<Object> objects) {
+                return Tuple.of((T1) objects.get(0), (T2) objects.get(1), (T3) objects.get(2), (T4) objects.get(3), (T5) objects.get(4), (T6) objects.get(5));
+            }
+        });
+    }
+
+    /**
+     * Merge given promises into a new a {@literal Promise} that will be fulfilled when all of the given {@literal Promise
+     * Promises} have been fulfilled.
+     *
+     * @param p1, p2, p3, p4, p5, p6, p7
+     * 		The promises to use.
+     * @param <T1,T2,T3,T4,T5,T6,T7>
+     * 		The type of the function Tuple result.
+     *
+     * @return a {@link Promise}.
+     */
+    @SuppressWarnings("unchecked")
+    public static <T1,T2,T3,T4,T5,T6,T7> Promise<Tuple7<T1,T2,T3,T4,T5,T6,T7>> heterogeneousWhen(Promise<T1> p1, Promise<T2> p2, Promise<T3> p3, Promise<T4> p4, Promise<T5> p5, Promise<T6> p6, Promise<T7> p7) {
+        Promise<Object> untypedP1 = untypedPromise(p1);
+        Promise<Object> untypedP2 = untypedPromise(p2);
+        Promise<Object> untypedP3 = untypedPromise(p3);
+        Promise<Object> untypedP4 = untypedPromise(p4);
+        Promise<Object> untypedP5 = untypedPromise(p5);
+        Promise<Object> untypedP6 = untypedPromise(p6);
+        Promise<Object> untypedP7 = untypedPromise(p7);
+
+        return Promises.when(untypedP1, untypedP2, untypedP3, untypedP4, untypedP5, untypedP6, untypedP7).map(new Function<List<Object>, Tuple7<T1,T2,T3,T4,T5,T6,T7>>() {
+            @Override
+            public Tuple7<T1,T2,T3,T4,T5,T6,T7> apply(List<Object> objects) {
+                return Tuple.of((T1) objects.get(0), (T2) objects.get(1), (T3) objects.get(2), (T4) objects.get(3), (T5) objects.get(4), (T6) objects.get(5), (T7) objects.get(6));
+            }
+        });
+    }
+
+    /**
+     * Merge given promises into a new a {@literal Promise} that will be fulfilled when all of the given {@literal Promise
+     * Promises} have been fulfilled.
+     *
+     * @param p1, p2, p3, p4, p5, p6, p7, p8
+     * 		The promises to use.
+     * @param <T1,T2,T3,T4,T5,T6,T7,T8>
+     * 		The type of the function Tuple result.
+     *
+     * @return a {@link Promise}.
+     */
+    @SuppressWarnings("unchecked")
+    public static <T1,T2,T3,T4,T5,T6,T7,T8> Promise<Tuple8<T1,T2,T3,T4,T5,T6,T7,T8>> heterogeneousWhen(Promise<T1> p1, Promise<T2> p2, Promise<T3> p3, Promise<T4> p4, Promise<T5> p5, Promise<T6> p6, Promise<T7> p7, Promise<T8> p8) {
+        Promise<Object> untypedP1 = untypedPromise(p1);
+        Promise<Object> untypedP2 = untypedPromise(p2);
+        Promise<Object> untypedP3 = untypedPromise(p3);
+        Promise<Object> untypedP4 = untypedPromise(p4);
+        Promise<Object> untypedP5 = untypedPromise(p5);
+        Promise<Object> untypedP6 = untypedPromise(p6);
+        Promise<Object> untypedP7 = untypedPromise(p7);
+        Promise<Object> untypedP8 = untypedPromise(p8);
+
+        return Promises.when(untypedP1, untypedP2, untypedP3, untypedP4, untypedP5, untypedP6, untypedP7, untypedP8).map(new Function<List<Object>, Tuple8<T1,T2,T3,T4,T5,T6,T7,T8>>() {
+            @Override
+            public Tuple8<T1,T2,T3,T4,T5,T6,T7,T8> apply(List<Object> objects) {
+                return Tuple.of((T1) objects.get(0), (T2) objects.get(1), (T3) objects.get(2), (T4) objects.get(3), (T5) objects.get(4), (T6) objects.get(5), (T7) objects.get(6), (T8) objects.get(7));
+            }
+        });
+    }
+
+    /**
+     * Merge given promises into a new a {@literal Promise} that will be fulfilled when all of the given {@literal Promise
+     * Promises} have been fulfilled.
+     *
+     * @param p1, p2, p3, p4, p5, p6, p7, p8, pRest
+     * 		The promises to use.
+     * @param <T1,T2,T3,T4,T5,T6,T7,T8,TRest>
+     * 		The type of the function Tuple result.
+     *
+     * @return a {@link Promise}.
+     */
+    @SuppressWarnings("unchecked")
+    public static <T1,T2,T3,T4,T5,T6,T7,T8,TRest extends Tuple> Promise<TupleN<T1,T2,T3,T4,T5,T6,T7,T8,TRest>> heterogeneousWhen(Promise<T1> p1, Promise<T2> p2, Promise<T3> p3, Promise<T4> p4, Promise<T5> p5, Promise<T6> p6, Promise<T7> p7, Promise<T8> p8, Promise<TRest> pRest) {
+        Promise<Object> untypedP1 = untypedPromise(p1);
+        Promise<Object> untypedP2 = untypedPromise(p2);
+        Promise<Object> untypedP3 = untypedPromise(p3);
+        Promise<Object> untypedP4 = untypedPromise(p4);
+        Promise<Object> untypedP5 = untypedPromise(p5);
+        Promise<Object> untypedP6 = untypedPromise(p6);
+        Promise<Object> untypedP7 = untypedPromise(p7);
+        Promise<Object> untypedP8 = untypedPromise(p8);
+        Promise<Object> untypedPRest = untypedPromise(pRest);
+
+        return Promises.when(untypedP1, untypedP2, untypedP3, untypedP4, untypedP5, untypedP6, untypedP7, untypedP8, untypedPRest).map(new Function<List<Object>, TupleN<T1,T2,T3,T4,T5,T6,T7,T8,TRest>>() {
+            @Override
+            public TupleN<T1,T2,T3,T4,T5,T6,T7,T8,TRest> apply(List<Object> objects) {
+                return Tuple.of((T1) objects.get(0), (T2) objects.get(1), (T3) objects.get(2), (T4) objects.get(3), (T5) objects.get(4), (T6) objects.get(5), (T7) objects.get(6), (T8) objects.get(7), (TRest) objects.get(8));
+            }
+        });
+    }
+
+
+    /**
 	 * Merge given promises into a new a {@literal Promise} that will be fulfilled when all of the given {@literal Promise
 	 * Promises} have been fulfilled.
 	 *
@@ -346,5 +580,20 @@ public abstract class Promises {
 		}
 		return promiseList;
 	}
+
+    /**
+     * Just hide type of a given promise
+     * @param promise any promise to untyped
+     * @return an untyped promise
+     */
+    private static <T> Promise<Object> untypedPromise(Promise<T> promise) {
+        return promise.map(new Function<T, Object>() {
+            @Override
+            public Object apply(T o) {
+                return o;
+            }
+        });
+    }
+
 
 }


### PR DESCRIPTION
Hi,

After playing a bit with promises, I found Promises.when very useful when playing with "homogeneous" promise (Promise of the same type and mainly of the same origin/same functional domain).

For instance, if I call x times a method returning a "Promise<String>" with different parameters, I will join then with Promises.when to obtain a "Promise<List<String>>". 

But what if I would like to join "Promise" of different types and avoid to lose typed checking ?

I found the 'Tuple' version quite useful :

``` java

Promise<String> usernamePromise = username(xxx);
Promise<Integer> agePromise = username(yyy);

Promise<Tuple2<String, Integer>> usernameAndAgePromise = Promises.when(usernamePromise, agePromise);

```

I am not very satisfied with the implementation (because lambda are not available and because I repeat a lot of code) as well as the name of the method that cannot just be "when".

The given pull request is more to discuss about the advantage of such methods.

Waiting for your advice ! 
