### PR TITLE
Added Promises heterogeneous when

### DIFF
--- a/reactor-core/src/main/java/reactor/rx/spec/Promises.java
+++ b/reactor-core/src/main/java/reactor/rx/spec/Promises.java
@@ -20,10 +20,12 @@ import reactor.core.Environment;
 import reactor.event.dispatch.Dispatcher;
 import reactor.event.dispatch.SynchronousDispatcher;
 import reactor.function.Supplier;
+import reactor.function.Function;
 import reactor.rx.Promise;
 import reactor.rx.action.MergeAction;
 import reactor.rx.action.SupplierAction;
 import reactor.util.Assert;
+import reactor.tuple.*;
 
 import java.util.Arrays;
 import java.util.List;
@@ -200,17 +202,177 @@ public abstract class Promises {
 		return new Promise<T>(error, dispatcher, env);
 	}
 
-	/**
-	 * Aggregate given promises into a new a {@literal Promise} that will be fulfilled when all of the given {@literal
-	 * Promise Promises} have been fulfilled.
-	 *
-	 * @param promises The promises to use.
-	 * @param <T>      The type of the function result.
-	 * @return a {@link Promise}.
-	 */
-	public static <T> Promise<List<T>> when(Promise<T>... promises) {
-		return when(Arrays.asList(promises));
-	}
+
+
+
+    /**
+     * Merge given promises into a new a {@literal Promise} that will be fulfilled when all of the given {@literal Promise
+     * Promises} have been fulfilled.
+     *
+     * @param p1, p2
+     * 		The promises to use.
+     * @param <T1,T2>
+     * 		The type of the function Tuple result.
+     *
+     * @return a {@link Promise}.
+     */
+    @SuppressWarnings("unchecked")
+    public static <T1,T2> Promise<Tuple2<T1,T2>> when(Promise<T1> p1, Promise<T2> p2) {
+        return multiWhen(new Promise[] {p1, p2}).stream().map(new Function<List<Object>, Tuple2<T1,T2>>() {
+            @Override
+            public Tuple2<T1,T2> apply(List<Object> objects) {
+                return Tuple.of((T1) objects.get(0), (T2) objects.get(1));
+            }
+        }).next();
+    }
+
+    /**
+     * Merge given promises into a new a {@literal Promise} that will be fulfilled when all of the given {@literal Promise
+     * Promises} have been fulfilled.
+     *
+     * @param p1, p2, p3
+     * 		The promises to use.
+     * @param <T1,T2,T3>
+     * 		The type of the function Tuple result.
+     *
+     * @return a {@link Promise}.
+     */
+    @SuppressWarnings("unchecked")
+    public static <T1,T2,T3> Promise<Tuple3<T1,T2,T3>> when(Promise<T1> p1, Promise<T2> p2, Promise<T3> p3) {
+        return multiWhen(new Promise[] {p1, p2, p3}).stream().map(new Function<List<Object>, Tuple3<T1,T2,T3>>() {
+            @Override
+            public Tuple3<T1,T2,T3> apply(List<Object> objects) {
+                return Tuple.of((T1) objects.get(0), (T2) objects.get(1), (T3) objects.get(2));
+            }
+        }).next();
+    }
+
+    /**
+     * Merge given promises into a new a {@literal Promise} that will be fulfilled when all of the given {@literal Promise
+     * Promises} have been fulfilled.
+     *
+     * @param p1, p2, p3, p4
+     * 		The promises to use.
+     * @param <T1,T2,T3,T4>
+     * 		The type of the function Tuple result.
+     *
+     * @return a {@link Promise}.
+     */
+    @SuppressWarnings("unchecked")
+    public static <T1,T2,T3,T4> Promise<Tuple4<T1,T2,T3,T4>> when(Promise<T1> p1, Promise<T2> p2, Promise<T3> p3, Promise<T4> p4) {
+        return multiWhen(new Promise[] {p1, p2, p3, p4}).stream().map(new Function<List<Object>, Tuple4<T1,T2,T3,T4>>() {
+            @Override
+            public Tuple4<T1,T2,T3,T4> apply(List<Object> objects) {
+                return Tuple.of((T1) objects.get(0), (T2) objects.get(1), (T3) objects.get(2), (T4) objects.get(3));
+            }
+        }).next();
+    }
+
+    /**
+     * Merge given promises into a new a {@literal Promise} that will be fulfilled when all of the given {@literal Promise
+     * Promises} have been fulfilled.
+     *
+     * @param p1, p2, p3, p4, p5
+     * 		The promises to use.
+     * @param <T1,T2,T3,T4,T5>
+     * 		The type of the function Tuple result.
+     *
+     * @return a {@link Promise}.
+     */
+    @SuppressWarnings("unchecked")
+    public static <T1,T2,T3,T4,T5> Promise<Tuple5<T1,T2,T3,T4,T5>> when(Promise<T1> p1, Promise<T2> p2, Promise<T3> p3, Promise<T4> p4, Promise<T5> p5) {
+        return multiWhen(new Promise[] {p1, p2, p3, p4, p5}).stream().map(new Function<List<Object>, Tuple5<T1,T2,T3,T4,T5>>() {
+            @Override
+            public Tuple5<T1,T2,T3,T4,T5> apply(List<Object> objects) {
+                return Tuple.of((T1) objects.get(0), (T2) objects.get(1), (T3) objects.get(2), (T4) objects.get(3), (T5) objects.get(4));
+            }
+        }).next();
+    }
+
+    /**
+     * Merge given promises into a new a {@literal Promise} that will be fulfilled when all of the given {@literal Promise
+     * Promises} have been fulfilled.
+     *
+     * @param p1, p2, p3, p4, p5, p6
+     * 		The promises to use.
+     * @param <T1,T2,T3,T4,T5,T6>
+     * 		The type of the function Tuple result.
+     *
+     * @return a {@link Promise}.
+     */
+    @SuppressWarnings("unchecked")
+    public static <T1,T2,T3,T4,T5,T6> Promise<Tuple6<T1,T2,T3,T4,T5,T6>> when(Promise<T1> p1, Promise<T2> p2, Promise<T3> p3, Promise<T4> p4, Promise<T5> p5, Promise<T6> p6) {
+        return multiWhen(new Promise[] {p1, p2, p3, p4, p5, p6}).stream().map(new Function<List<Object>, Tuple6<T1,T2,T3,T4,T5,T6>>() {
+            @Override
+            public Tuple6<T1,T2,T3,T4,T5,T6> apply(List<Object> objects) {
+                return Tuple.of((T1) objects.get(0), (T2) objects.get(1), (T3) objects.get(2), (T4) objects.get(3), (T5) objects.get(4), (T6) objects.get(5));
+            }
+        }).next();
+    }
+
+    /**
+     * Merge given promises into a new a {@literal Promise} that will be fulfilled when all of the given {@literal Promise
+     * Promises} have been fulfilled.
+     *
+     * @param p1, p2, p3, p4, p5, p6, p7
+     * 		The promises to use.
+     * @param <T1,T2,T3,T4,T5,T6,T7>
+     * 		The type of the function Tuple result.
+     *
+     * @return a {@link Promise}.
+     */
+    @SuppressWarnings("unchecked")
+    public static <T1,T2,T3,T4,T5,T6,T7> Promise<Tuple7<T1,T2,T3,T4,T5,T6,T7>> when(Promise<T1> p1, Promise<T2> p2, Promise<T3> p3, Promise<T4> p4, Promise<T5> p5, Promise<T6> p6, Promise<T7> p7) {
+        return multiWhen(new Promise[] {p1, p2, p3, p4, p5, p6, p7}).stream().map(new Function<List<Object>, Tuple7<T1,T2,T3,T4,T5,T6,T7>>() {
+            @Override
+            public Tuple7<T1,T2,T3,T4,T5,T6,T7> apply(List<Object> objects) {
+                return Tuple.of((T1) objects.get(0), (T2) objects.get(1), (T3) objects.get(2), (T4) objects.get(3), (T5) objects.get(4), (T6) objects.get(5), (T7) objects.get(6));
+            }
+        }).next();
+    }
+
+    /**
+     * Merge given promises into a new a {@literal Promise} that will be fulfilled when all of the given {@literal Promise
+     * Promises} have been fulfilled.
+     *
+     * @param p1, p2, p3, p4, p5, p6, p7, p8
+     * 		The promises to use.
+     * @param <T1,T2,T3,T4,T5,T6,T7,T8>
+     * 		The type of the function Tuple result.
+     *
+     * @return a {@link Promise}.
+     */
+    @SuppressWarnings("unchecked")
+    public static <T1,T2,T3,T4,T5,T6,T7,T8> Promise<Tuple8<T1,T2,T3,T4,T5,T6,T7,T8>> when(Promise<T1> p1, Promise<T2> p2, Promise<T3> p3, Promise<T4> p4, Promise<T5> p5, Promise<T6> p6, Promise<T7> p7, Promise<T8> p8) {
+        return multiWhen(new Promise[] {p1, p2, p3, p4, p5, p6, p7, p8}).stream().map(new Function<List<Object>, Tuple8<T1,T2,T3,T4,T5,T6,T7,T8>>() {
+            @Override
+            public Tuple8<T1,T2,T3,T4,T5,T6,T7,T8> apply(List<Object> objects) {
+                return Tuple.of((T1) objects.get(0), (T2) objects.get(1), (T3) objects.get(2), (T4) objects.get(3), (T5) objects.get(4), (T6) objects.get(5), (T7) objects.get(6), (T8) objects.get(7));
+            }
+        }).next();
+    }
+
+    /**
+     * Merge given promises into a new a {@literal Promise} that will be fulfilled when all of the given {@literal Promise
+     * Promises} have been fulfilled.
+     *
+     * @param p1, p2, p3, p4, p5, p6, p7, p8, pRest
+     * 		The promises to use.
+     * @param <T1,T2,T3,T4,T5,T6,T7,T8,TRest>
+     * 		The type of the function Tuple result.
+     *
+     * @return a {@link Promise}.
+     */
+    @SuppressWarnings("unchecked")
+    public static <T1,T2,T3,T4,T5,T6,T7,T8,TRest extends Tuple> Promise<TupleN<T1,T2,T3,T4,T5,T6,T7,T8,TRest>> when(Promise<T1> p1, Promise<T2> p2, Promise<T3> p3, Promise<T4> p4, Promise<T5> p5, Promise<T6> p6, Promise<T7> p7, Promise<T8> p8, Promise<TRest> pRest) {
+        return multiWhen(new Promise[] {p1, p2, p3, p4, p5, p6, p7, p8, pRest}).stream().map(new Function<List<Object>, TupleN<T1,T2,T3,T4,T5,T6,T7,T8,TRest>>() {
+            @Override
+            public TupleN<T1,T2,T3,T4,T5,T6,T7,T8,TRest> apply(List<Object> objects) {
+                return Tuple.of((T1) objects.get(0), (T2) objects.get(1), (T3) objects.get(2), (T4) objects.get(3), (T5) objects.get(4), (T6) objects.get(5), (T7) objects.get(6), (T8) objects.get(7), (TRest) objects.get(8));
+            }
+        }).next();
+    }
+
 
 	/**
 	 * Aggregate given promises into a new a {@literal Promise} that will be fulfilled when all of the given {@literal
@@ -258,5 +420,18 @@ public abstract class Promises {
 
 		return mergeAction.next();
 	}
+
+
+    /**
+     * Aggregate given promises into a new a {@literal Promise} that will be fulfilled when all of the given {@literal
+     * Promise Promises} have been fulfilled.
+     *
+     * @param promises The promises to use.
+     * @param <T>      The type of the function result.
+     * @return a {@link Promise}.
+     */
+    private static <T> Promise<List<T>> multiWhen(Promise<T>... promises) {
+        return when(Arrays.asList(promises));
+    }
 
 }


### PR DESCRIPTION
Hi,

After playing a bit with promises, I found Promises.when very useful when playing with "homogeneous" promise (Promise of the same type and mainly of the same origin/same functional domain).

For instance, if I call x times a method returning a "Promise" with different parameters, I will join then with Promises.when to obtain a "Promise>".

But what if I would like to join "Promise" of different types and avoid to lose typed checking ?

I found the 'Tuple' version quite useful :

Promise<String> usernamePromise = username(xxx);
Promise<Integer> agePromise = username(yyy);

Promise<Tuple2<String, Integer>> usernameAndAgePromise = Promises.when(usernamePromise, agePromise);

I am not very satisfied with the implementation (because lambda are not available and because I repeat a lot of code) as well as the name of the method that cannot just be "when".

I will try to improve the implementation. If you think about a great name, feel free to propose.
