### PR TITLE
Refactor GS Collections usages.

### DIFF
--- a/reactor-core/src/main/java/reactor/core/fork/ForkJoinPool.java
+++ b/reactor-core/src/main/java/reactor/core/fork/ForkJoinPool.java
@@ -17,6 +17,7 @@
 package reactor.core.fork;
 
 import com.gs.collections.api.list.ImmutableList;
+import com.gs.collections.api.list.MutableList;
 import com.gs.collections.impl.list.mutable.FastList;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -94,7 +95,7 @@ public class ForkJoinPool {
 				= new ForkJoinTask<ImmutableList<V>, HotStream<ImmutableList<V>>>(executor, d);
 
 		final AtomicInteger count = new AtomicInteger(tasks.size());
-		final FastList<V> results = FastList.newList();
+		final MutableList<V> results = FastList.newList();
 
 		for (final Function fn : tasks) {
 			t.add(new Function<Object, ImmutableList<V>>() {

--- a/reactor-core/src/test/java/reactor/core/fork/ForkJoinPoolTests.java
+++ b/reactor-core/src/test/java/reactor/core/fork/ForkJoinPoolTests.java
@@ -1,6 +1,7 @@
 package reactor.core.fork;
 
 import com.gs.collections.api.list.ImmutableList;
+import com.gs.collections.api.list.MutableList;
 import com.gs.collections.impl.list.mutable.FastList;
 import org.junit.After;
 import org.junit.Before;
@@ -55,7 +56,7 @@ public class ForkJoinPoolTests {
 			}
 		};
 
-		List<Function<?, Integer>> tasks = FastList.newList();
+		MutableList<Function<?, Integer>> tasks = FastList.newList();
 		for (int i = 0; i < runs; i++) {
 			tasks.add(task);
 		}

--- a/reactor-net/src/main/java/reactor/net/AbstractNetPeer.java
+++ b/reactor-net/src/main/java/reactor/net/AbstractNetPeer.java
@@ -16,6 +16,7 @@
 
 package reactor.net;
 
+import com.gs.collections.api.list.MutableList;
 import com.gs.collections.impl.list.mutable.FastList;
 import reactor.core.Environment;
 import reactor.core.Reactor;
@@ -94,7 +95,7 @@ public abstract class AbstractNetPeer<IN, OUT> {
 	}
 
 	public Iterator<NetChannel<IN, OUT>> iterator() {
-		FastList<NetChannel<IN, OUT>> channels = FastList.newList();
+		MutableList<NetChannel<IN, OUT>> channels = FastList.newList();
 		for (Registration<? extends NetChannel<IN, OUT>> reg : getChannels()) {
 			channels.add(reg.getObject());
 		}

--- a/reactor-net/src/main/java/reactor/net/zmq/ZeroMQNetChannel.java
+++ b/reactor-net/src/main/java/reactor/net/zmq/ZeroMQNetChannel.java
@@ -16,10 +16,9 @@
 
 package reactor.net.zmq;
 
+import com.gs.collections.api.block.predicate.Predicate;
 import com.gs.collections.api.list.MutableList;
-import com.gs.collections.impl.block.predicate.checked.CheckedPredicate;
 import com.gs.collections.impl.list.mutable.FastList;
-import com.gs.collections.impl.list.mutable.SynchronizedMutableList;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.zeromq.ZFrame;
@@ -51,7 +50,7 @@ public class ZeroMQNetChannel<IN, OUT> extends AbstractNetChannel<IN, OUT> {
 
 	private final Logger                log           = LoggerFactory.getLogger(getClass());
 	private final ZeroMQConsumerSpec    eventSpec     = new ZeroMQConsumerSpec();
-	private final MutableList<Runnable> closeHandlers = SynchronizedMutableList.of(FastList.<Runnable>newList());
+	private final MutableList<Runnable> closeHandlers = FastList.<Runnable>newList().asSynchronized();
 
 	private volatile String     connectionId;
 	private volatile ZMQ.Socket socket;
@@ -132,9 +131,9 @@ public class ZeroMQNetChannel<IN, OUT> extends AbstractNetChannel<IN, OUT> {
 		getEventsReactor().schedule(new Consumer<Void>() {
 			@Override
 			public void accept(Void v) {
-				closeHandlers.removeIf(new CheckedPredicate<Runnable>() {
+				closeHandlers.removeIf(new Predicate<Runnable>() {
 					@Override
-					public boolean safeAccept(Runnable r) throws Exception {
+					public boolean accept(Runnable r) {
 						r.run();
 						return true;
 					}

--- a/reactor-net/src/main/java/reactor/net/zmq/tcp/ZeroMQ.java
+++ b/reactor-net/src/main/java/reactor/net/zmq/tcp/ZeroMQ.java
@@ -16,12 +16,11 @@
 
 package reactor.net.zmq.tcp;
 
+import com.gs.collections.api.block.function.Function0;
 import com.gs.collections.api.list.MutableList;
-import com.gs.collections.impl.block.function.checked.CheckedFunction0;
+import com.gs.collections.api.map.MutableMap;
 import com.gs.collections.impl.block.predicate.checked.CheckedPredicate;
 import com.gs.collections.impl.list.mutable.FastList;
-import com.gs.collections.impl.list.mutable.SynchronizedMutableList;
-import com.gs.collections.impl.map.mutable.SynchronizedMutableMap;
 import com.gs.collections.impl.map.mutable.UnifiedMap;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -56,11 +55,11 @@ import java.util.concurrent.TimeUnit;
  */
 public class ZeroMQ<T> {
 
-	private static final SynchronizedMutableMap<Integer, String> SOCKET_TYPES = SynchronizedMutableMap.of(UnifiedMap.<Integer, String>newMap());
+	private static final MutableMap<Integer, String> SOCKET_TYPES = UnifiedMap.<Integer, String>newMap().asSynchronized();
 
 	private final Logger                       log     = LoggerFactory.getLogger(getClass());
-	private final MutableList<TcpClient<T, T>> clients = SynchronizedMutableList.of(FastList.<TcpClient<T, T>>newList());
-	private final MutableList<TcpServer<T, T>> servers = SynchronizedMutableList.of(FastList.<TcpServer<T, T>>newList());
+	private final MutableList<TcpClient<T, T>> clients = FastList.<TcpClient<T, T>>newList().asSynchronized();
+	private final MutableList<TcpServer<T, T>> servers = FastList.<TcpServer<T, T>>newList().asSynchronized();
 
 	private final ExecutorService threadPool = Executors.newCachedThreadPool(new NamedDaemonThreadFactory("zmq"));
 
@@ -90,9 +89,9 @@ public class ZeroMQ<T> {
 	}
 
 	public static String findSocketTypeName(final int socketType) {
-		return SOCKET_TYPES.getIfAbsentPut(socketType, new CheckedFunction0<String>() {
+		return SOCKET_TYPES.getIfAbsentPut(socketType, new Function0<String>() {
 			@Override
-			public String safeValue() throws Exception {
+			public String value() {
 				for (Field f : ZMQ.class.getDeclaredFields()) {
 					if (int.class.isAssignableFrom(f.getType())) {
 						f.setAccessible(true);

--- a/reactor-net/src/main/java/reactor/net/zmq/tcp/ZeroMQTcpClient.java
+++ b/reactor-net/src/main/java/reactor/net/zmq/tcp/ZeroMQTcpClient.java
@@ -18,7 +18,6 @@ package reactor.net.zmq.tcp;
 
 import com.gs.collections.api.map.MutableMap;
 import com.gs.collections.impl.block.procedure.checked.CheckedProcedure2;
-import com.gs.collections.impl.map.mutable.SynchronizedMutableMap;
 import com.gs.collections.impl.map.mutable.UnifiedMap;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -62,7 +61,7 @@ public class ZeroMQTcpClient<IN, OUT> extends TcpClient<IN, OUT> {
 
 	private final Logger                                       log     = LoggerFactory.getLogger(getClass());
 	private final MutableMap<ZeroMQWorker<IN, OUT>, Future<?>> workers =
-			SynchronizedMutableMap.of(UnifiedMap.<ZeroMQWorker<IN, OUT>, Future<?>>newMap());
+			UnifiedMap.<ZeroMQWorker<IN, OUT>, Future<?>>newMap().asSynchronized();
 
 	private final int                       ioThreadCount;
 	private final ZeroMQClientSocketOptions zmqOpts;

--- a/reactor-net/src/test/java/reactor/net/AbstractNetClientServerTest.java
+++ b/reactor-net/src/test/java/reactor/net/AbstractNetClientServerTest.java
@@ -1,6 +1,7 @@
 package reactor.net;
 
-import com.gs.collections.api.RichIterable;
+import com.gs.collections.api.list.ImmutableList;
+import com.gs.collections.api.list.MutableList;
 import com.gs.collections.impl.list.mutable.FastList;
 import org.junit.After;
 import org.junit.Before;
@@ -190,8 +191,8 @@ public class AbstractNetClientServerTest {
 		return serverPool.submit(r);
 	}
 
-	protected RichIterable<Future<?>> submitClients(Runnable r) {
-		FastList<Future<?>> futures = FastList.newList();
+	protected ImmutableList<Future<?>> submitClients(Runnable r) {
+		MutableList<Future<?>> futures = FastList.newList();
 		for (int i = 0; i < senderThreads; i++) {
 			futures.add(clientPool.submit(r));
 		}


### PR DESCRIPTION
The main change is to use the asSynchronized method instead of calling factory methods on the synchronized wrappers.

The second change is to use interfaces instead of concrete classes where possible.