### PR TITLE
Fix for https://github.com/reactor/reactor/issues/405. 

### DIFF
--- a/reactor-logback/src/main/java/reactor/logback/AsyncAppender.java
+++ b/reactor-logback/src/main/java/reactor/logback/AsyncAppender.java
@@ -103,9 +103,7 @@ public class AsyncAppender
 
 	@Override
 	public void start() {
-		if (null != delegate.get()) {
-			delegate.get().start();
-		}
+    startDelegateAppender();
 
 		processor = new ProcessorSpec<LogEvent>()
 				.dataSupplier(new Supplier<LogEvent>() {
@@ -138,6 +136,13 @@ public class AsyncAppender
 			started = true;
 		}
 	}
+
+  private void startDelegateAppender() {
+    Appender<ILoggingEvent> delegateAppender = delegate.get();
+    if (null != delegateAppender && !delegateAppender.isStarted()) {
+      delegateAppender.start();
+    }
+  }
 
 	@Override
 	public void stop() {


### PR DESCRIPTION
When using an AsyncAppender and a delegate appender, the logback framework starts the delegate appender first and then the AsyncAppender starts it again in start() method. So in case of using an outputStream appender as delegate, the outputStream is opened, closed and opened again.
