### PR TITLE
upgrade shadow to support gradle 2.2+

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -65,7 +65,7 @@ buildscript {
 	dependencies {
 		classpath 'org.springframework.build.gradle:propdeps-plugin:0.0.7',
 							'org.springframework.build.gradle:spring-io-plugin:0.0.3.RELEASE',
-							'com.github.jengelman.gradle.plugins:shadow:1.1.1'
+							'com.github.jengelman.gradle.plugins:shadow:1.2.0'
 	}
 }
 apply from: "$gradleScriptDir/setup.gradle"


### PR DESCRIPTION
Just a version bump to support Gradle 2.2 and higher. Without this, users with Gradle 2.2 will see something like the following when deployed:

```
~/s/reactor ❯❯❯ gradle uploadArchives                                                                                                                                                                                   ⏎

FAILURE: Build failed with an exception.

* Where:
Build file '/Users/jpollak/src/reactor/build.gradle' line: 389

* What went wrong:
A problem occurred evaluating root project 'reactor'.
> Failed to apply plugin [id 'com.github.johnrengelman.shadow']
   > No signature of method: com.github.jengelman.gradle.plugins.shadow.tasks.ShadowJar_Decorated.getManifest() is applicable for argument types: () values: []
     Possible solutions: getManifest(), getManifest(), getManifest(), setManifest(org.gradle.api.java.archives.Manifest), setManifest(org.gradle.api.java.archives.Manifest), manifest(groovy.lang.Closure)

* Try:
Run with --stacktrace option to get the stack trace. Run with --info or --debug option to get more log output.

BUILD FAILED

Total time: 6.449 secs
```