### PR TITLE
Add SimpleCachingRegistry alternative specifically for Android

### DIFF
--- a/reactor-core/src/main/java/reactor/bus/EventBus.java
+++ b/reactor-core/src/main/java/reactor/bus/EventBus.java
@@ -22,6 +22,7 @@ import reactor.Environment;
 import reactor.bus.filter.PassThroughFilter;
 import reactor.bus.registry.CachingRegistry;
 import reactor.bus.registry.Registration;
+import reactor.bus.registry.Registries;
 import reactor.bus.registry.Registry;
 import reactor.bus.routing.ConsumerFilteringRouter;
 import reactor.bus.routing.Router;
@@ -168,7 +169,7 @@ public class EventBus implements Observable<Event<?>>, Consumer<Event<?>> {
 	                @Nullable Router router,
 	                @Nullable Consumer<Throwable> dispatchErrorHandler,
 	                @Nullable final Consumer<Throwable> uncaughtErrorHandler) {
-		this(new CachingRegistry<Consumer<? extends Event<?>>>(),
+		this(Registries.<Consumer<? extends Event<?>>>create(),
 				dispatcher,
 				router,
 				dispatchErrorHandler,

--- a/reactor-core/src/main/java/reactor/bus/registry/CachingRegistry.java
+++ b/reactor-core/src/main/java/reactor/bus/registry/CachingRegistry.java
@@ -45,11 +45,7 @@ public class CachingRegistry<T> implements Registry<T> {
 	private final MultiReaderFastList<Registration<? extends T>>                                 registrations;
 	private final ConcurrentHashMapV8<Long, UnifiedMap<Object, List<Registration<? extends T>>>> threadLocalCache;
 
-	public CachingRegistry() {
-		this(true, true, null);
-	}
-
-	public CachingRegistry(boolean useCache, boolean cacheNotFound, Consumer<Object> onNotFound) {
+	 CachingRegistry(boolean useCache, boolean cacheNotFound, Consumer<Object> onNotFound) {
 		this.useCache = useCache;
 		this.cacheNotFound = cacheNotFound;
 		this.onNotFound = onNotFound;

--- a/reactor-core/src/main/java/reactor/bus/registry/Registries.java
+++ b/reactor-core/src/main/java/reactor/bus/registry/Registries.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright (c) 2011-2015 Pivotal Software, Inc.
+ *  
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *  
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *  
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package reactor.bus.registry;
+
+import reactor.fn.Consumer;
+
+/**
+ * Created by jbrisbin on 1/27/15.
+ */
+public abstract class Registries {
+
+	private static boolean GS_COLLECTIONS_AVAILABLE = false;
+
+	static {
+		try {
+			GS_COLLECTIONS_AVAILABLE = (null != Class.forName("com.gs.collections.api.list.MutableList"));
+		} catch (ClassNotFoundException e) {
+		}
+	}
+
+	protected Registries() {
+	}
+
+	@SuppressWarnings("unchecked")
+	public static <T> Registry<T> create() {
+		return create(true, true, null);
+	}
+
+	public static <T> Registry<T> create(boolean useCache, boolean cacheNotFound, Consumer<Object> onNotFound) {
+		if (GS_COLLECTIONS_AVAILABLE) {
+			return new reactor.bus.registry.CachingRegistry<T>(useCache, cacheNotFound, onNotFound);
+		} else {
+			return new reactor.bus.registry.SimpleCachingRegistry<T>(useCache, cacheNotFound, onNotFound);
+		}
+	}
+
+}

--- a/reactor-core/src/main/java/reactor/bus/registry/SimpleCachingRegistry.java
+++ b/reactor-core/src/main/java/reactor/bus/registry/SimpleCachingRegistry.java
@@ -1,0 +1,133 @@
+/*
+ * Copyright (c) 2011-2015 Pivotal Software, Inc.
+ *  
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *  
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *  
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package reactor.bus.registry;
+
+import reactor.bus.selector.Selector;
+import reactor.fn.Consumer;
+import reactor.jarjar.jsr166e.ConcurrentHashMapV8;
+
+import java.util.ArrayList;
+import java.util.Iterator;
+import java.util.List;
+
+/**
+ * A naive caching Registry implementation for use in situations that the default {@code CachingRegistry} can't be used
+ * due to its reliance on the gs-collections library. Not designed for high throughput but for use on things like
+ * handheld devices, where the synchronized nature of the registry won't affect performance much.
+ */
+public class SimpleCachingRegistry<T> implements Registry<T> {
+
+	private final ConcurrentHashMapV8<Object, List<Registration<? extends T>>>   cache         = new ConcurrentHashMapV8<Object, List<Registration<? extends T>>>();
+	private final ConcurrentHashMapV8<Selector, List<Registration<? extends T>>> registrations = new ConcurrentHashMapV8<Selector, List<Registration<? extends T>>>();
+
+	private final boolean          useCache;
+	private final boolean          cacheNotFound;
+	private final Consumer<Object> onNotFound;
+
+	SimpleCachingRegistry(boolean useCache, boolean cacheNotFound, Consumer<Object> onNotFound) {
+		this.useCache = useCache;
+		this.cacheNotFound = cacheNotFound;
+		this.onNotFound = onNotFound;
+	}
+
+	@Override
+	public synchronized Registration<T> register(final Selector sel, T obj) {
+		List<Registration<? extends T>> regs;
+		if (null == (regs = registrations.get(sel))) {
+			regs = registrations.computeIfAbsent(sel,
+			                                     new ConcurrentHashMapV8.Fun<Selector, List<Registration<? extends T>>>() {
+				                                     @Override
+				                                     public List<Registration<? extends T>> apply(Selector selector) {
+					                                     return new ArrayList<Registration<? extends T>>();
+				                                     }
+			                                     });
+		}
+
+		Registration<T> reg = new CachableRegistration<>(sel, obj, new Runnable() {
+			@Override
+			public void run() {
+				registrations.remove(sel);
+				cache.clear();
+			}
+		});
+		regs.add(reg);
+
+		return reg;
+	}
+
+	@Override
+	public synchronized boolean unregister(Object key) {
+		boolean found = false;
+		for (Selector sel : registrations.keySet()) {
+			if (!sel.matches(key)) {
+				continue;
+			}
+			if (null != registrations.remove(sel) && !found) {
+				found = true;
+			}
+		}
+		if (useCache)
+			cache.remove(key);
+		return found;
+	}
+
+	@Override
+	public synchronized List<Registration<? extends T>> select(final Object key) {
+		List<Registration<? extends T>> selectedRegs;
+		if (null != (selectedRegs = cache.get(key))) {
+			return selectedRegs;
+		}
+
+		final List<Registration<? extends T>> regs = new ArrayList<Registration<? extends T>>();
+		registrations.forEach(new ConcurrentHashMapV8.BiAction<Selector, List<Registration<? extends T>>>() {
+			@Override
+			public void apply(Selector selector, List<Registration<? extends T>> registrations) {
+				if (selector.matches(key)) {
+					regs.addAll(registrations);
+				}
+			}
+		});
+
+		if (regs.isEmpty() && null != onNotFound) {
+			onNotFound.accept(key);
+		}
+		if (useCache && (!regs.isEmpty() || cacheNotFound)) {
+			cache.put(key, regs);
+		}
+
+		return regs;
+	}
+
+	@Override
+	public synchronized void clear() {
+		cache.clear();
+		registrations.clear();
+	}
+
+	@Override
+	public synchronized Iterator<Registration<? extends T>> iterator() {
+		final List<Registration<? extends T>> regs = new ArrayList<Registration<? extends T>>();
+		registrations.forEach(new ConcurrentHashMapV8.BiAction<Selector, List<Registration<? extends T>>>() {
+			@Override
+			public void apply(Selector selector, List<Registration<? extends T>> registrations) {
+				regs.addAll(registrations);
+			}
+		});
+		return regs.iterator();
+	}
+
+}

--- a/reactor-core/src/main/java/reactor/bus/spec/EventRoutingComponentSpec.java
+++ b/reactor-core/src/main/java/reactor/bus/spec/EventRoutingComponentSpec.java
@@ -20,6 +20,7 @@ import reactor.bus.Event;
 import reactor.bus.EventBus;
 import reactor.bus.filter.*;
 import reactor.bus.registry.CachingRegistry;
+import reactor.bus.registry.Registries;
 import reactor.bus.registry.Registry;
 import reactor.bus.routing.ConsumerFilteringRouter;
 import reactor.bus.routing.Router;
@@ -195,7 +196,7 @@ public abstract class EventRoutingComponentSpec<SPEC extends EventRoutingCompone
 	 * @return {@code this}
 	 */
 	public SPEC consumerNotFoundHandler(Consumer<Object> consumerNotFoundHandler) {
-		this.consumerRegistry = new CachingRegistry<Consumer<? extends Event<?>>>(true, true, consumerNotFoundHandler);
+		this.consumerRegistry = Registries.create(true,true,consumerNotFoundHandler);
 		return (SPEC) this;
 	}
 
@@ -242,7 +243,7 @@ public abstract class EventRoutingComponentSpec<SPEC extends EventRoutingCompone
 	}
 
 	private Registry createRegistry() {
-		return new CachingRegistry<Consumer<? extends Event<?>>>();
+		return Registries.create();
 	}
 
 	protected enum EventRoutingStrategy {

--- a/reactor-core/src/main/java/reactor/core/dispatch/processor/spec/ProcessorSpec.java
+++ b/reactor-core/src/main/java/reactor/core/dispatch/processor/spec/ProcessorSpec.java
@@ -17,6 +17,7 @@
 package reactor.core.dispatch.processor.spec;
 
 import reactor.bus.registry.CachingRegistry;
+import reactor.bus.registry.Registries;
 import reactor.bus.registry.Registry;
 import reactor.bus.selector.Selectors;
 import reactor.core.dispatch.processor.Processor;
@@ -32,7 +33,7 @@ import reactor.jarjar.com.lmax.disruptor.*;
  */
 public class ProcessorSpec<T> implements Supplier<Processor<T>> {
 
-	private Registry<Consumer<Throwable>> errorConsumers        = new CachingRegistry<Consumer<Throwable>>();
+	private Registry<Consumer<Throwable>> errorConsumers        = Registries.create();
 	private boolean                       multiThreadedProducer = false;
 	private int                           dataBufferSize        = -1;
 	private WaitStrategy                  waitStrategy          = null;

--- a/reactor-core/src/test/groovy/reactor/bus/RegistrySpec.groovy
+++ b/reactor-core/src/test/groovy/reactor/bus/RegistrySpec.groovy
@@ -1,0 +1,55 @@
+/*
+ * Copyright (c) 2011-2015 Pivotal Software, Inc.
+ *  
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *  
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *  
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package reactor.bus
+
+import reactor.bus.registry.CachingRegistry
+import reactor.bus.registry.Registry
+import reactor.bus.registry.SimpleCachingRegistry
+import spock.lang.Specification
+
+import static reactor.bus.selector.Selectors.$
+
+/**
+ * Created by jbrisbin on 1/29/15.
+ */
+class RegistrySpec extends Specification {
+
+  def "Registry tracks Registrations"(Registry<String> regs) {
+
+    given: "simple Registrations"
+      regs.register $("Hello"), "World!"
+
+    when: "Registration is selected"
+      def r = regs.select("Hello")
+
+    then: "a Registration was found"
+      r.size() == 1
+      r[0].object == "World!"
+
+    when: "Registration is cancelled"
+      r[0].cancel()
+
+    then: "Registration is not found on subsequent search"
+      !regs.select("Hello")
+
+    where:
+      regs << [new CachingRegistry<String>(true, true, null),
+               new SimpleCachingRegistry<String>(true, true, null)]
+
+  }
+
+}

--- a/reactor-core/src/test/java/reactor/bus/SelectorUnitTests.java
+++ b/reactor-core/src/test/java/reactor/bus/SelectorUnitTests.java
@@ -22,6 +22,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import reactor.bus.registry.CachingRegistry;
 import reactor.bus.registry.Registration;
+import reactor.bus.registry.Registries;
 import reactor.bus.registry.Registry;
 import reactor.bus.selector.Selector;
 import reactor.bus.selector.Selectors;
@@ -128,7 +129,7 @@ public class SelectorUnitTests {
 
 	private void runTest(String type, Function<Integer, Tuple2<Selector, Object>> fn) {
 		final AtomicLong counter = new AtomicLong(selectors * iterations);
-		Registry<Consumer<?>> registry = new CachingRegistry<Consumer<?>>();
+		Registry<Consumer<?>> registry = Registries.create();
 
 		Consumer<?> countDown = new Consumer<Object>() {
 			@Override

--- a/reactor-core/src/test/java/reactor/bus/registry/CachingRegistryTests.java
+++ b/reactor-core/src/test/java/reactor/bus/registry/CachingRegistryTests.java
@@ -14,12 +14,9 @@
  * limitations under the License.
  */
 
-package reactor.bus;
+package reactor.bus.registry;
 
 import org.junit.Test;
-import reactor.bus.registry.CachingRegistry;
-import reactor.bus.registry.Registration;
-import reactor.bus.registry.Registry;
 import reactor.bus.selector.ObjectSelector;
 import reactor.bus.selector.Selector;
 import reactor.bus.selector.Selectors;
@@ -145,7 +142,7 @@ public final class CachingRegistryTests {
 		// notify1
 		List<Registration<?>> registrations = this.cachingRegistry.select("test");
 
-		assertEquals( "number of consumers incorrect", 1, registrations.size());
+		assertEquals("number of consumers incorrect", 1, registrations.size());
 
 
 		// consumer2
@@ -167,10 +164,10 @@ public final class CachingRegistryTests {
 
 		// notify2
 		registrations = this.cachingRegistry.select("test");
-		assertEquals( "number of consumers incorrect", 3, registrations.size());
+		assertEquals("number of consumers incorrect", 3, registrations.size());
 
 		registrations = this.cachingRegistry.select("test2");
-		assertEquals( "number of consumers incorrect", 2, registrations.size());
+		assertEquals("number of consumers incorrect", 2, registrations.size());
 
 
 		/*for(Registration<?> registration : registrations){
@@ -182,6 +179,7 @@ public final class CachingRegistryTests {
 		private final AtomicInteger cacheMisses;
 
 		public CacheMissCountingCachingRegistry(AtomicInteger cacheMisses) {
+			super(true, true, null);
 			this.cacheMisses = cacheMisses;
 		}
 

--- a/reactor-groovy/src/main/groovy/reactor/groovy/config/ReactorBuilder.groovy
+++ b/reactor-groovy/src/main/groovy/reactor/groovy/config/ReactorBuilder.groovy
@@ -9,6 +9,7 @@ import reactor.bus.Event
 import reactor.bus.EventBus
 import reactor.bus.filter.*
 import reactor.bus.registry.CachingRegistry
+import reactor.bus.registry.Registries
 import reactor.bus.routing.Router
 import reactor.bus.selector.Selector
 import reactor.bus.selector.Selectors
@@ -203,7 +204,7 @@ class ReactorBuilder implements Supplier<EventBus> {
 			spec.eventRouter(router)
 		} else if (processors) {
 
-			def registry = new CachingRegistry<Processor<Event<?>,Event<?>>>()
+			def registry = Registries.<Processor<Event<?>,Event<?>>>create()
 			Iterator<SelectorProcessor> it = processors.iterator()
 			SelectorProcessor p
 			while(it.hasNext()){


### PR DESCRIPTION
This change introduces a new Registry implementation that doesn't use the gs-collections library and is intended for use in situations where gs-collections causes problems when creating a final application, like on Android. To make use of this Registry, the gs-collections library must be excluded from the classpath so the factory method will discover that it needs to use the SimpleCachingRegistry instead of the default.