### PR TITLE
#438 Set the ByteBuffer limit to its new capacity by Buffer auto expansi...

### DIFF
--- a/reactor-core/src/main/java/reactor/io/buffer/Buffer.java
+++ b/reactor-core/src/main/java/reactor/io/buffer/Buffer.java
@@ -1348,6 +1348,7 @@ public class Buffer implements Recyclable,
 				buffer.limit(Math.min(pos + atLeast, cap));
 			} else {
 				expand();
+				buffer.limit(buffer.capacity());
 			}
 		} else if(pos + SMALL_BUFFER_SIZE > MAX_BUFFER_SIZE) {
 			throw new BufferOverflowException();

--- a/reactor-core/src/test/java/reactor/io/buffer/BufferTests.java
+++ b/reactor-core/src/test/java/reactor/io/buffer/BufferTests.java
@@ -1,0 +1,22 @@
+package reactor.io.buffer;
+
+import static org.junit.Assert.*;
+
+import org.junit.Test;
+
+/**
+ * @author Sergey Shcherbakov
+ */
+public class BufferTests {
+
+	@Test
+	public void testAutoExpand() {
+		Buffer b = new Buffer();
+		Buffer.SMALL_BUFFER_SIZE = 20;		// to speed up the test
+		Buffer.MAX_BUFFER_SIZE = 100;		
+		for(int i=0; i< Buffer.MAX_BUFFER_SIZE - Buffer.SMALL_BUFFER_SIZE; i++) {
+			b.append((byte)0x1);
+		}
+	}
+
+}


### PR DESCRIPTION
...on to avoid BufferOverflowException

A BufferOverflowException is being thrown on first Buffer auto-expansion attempt when
using default Buffer.SMALL_BUFFER_SIZE and Buffer.MAX_BUFFER_SIZE values.
This is a unit test illustrating the issue and a fix for it.