### PR TITLE
#438 improve unit test to leave static state in tact

### DIFF
--- a/reactor-core/src/test/java/reactor/io/buffer/BufferTests.java
+++ b/reactor-core/src/test/java/reactor/io/buffer/BufferTests.java
@@ -11,11 +11,20 @@ public class BufferTests {
 
 	@Test
 	public void testAutoExpand() {
-		Buffer b = new Buffer();
-		Buffer.SMALL_BUFFER_SIZE = 20;		// to speed up the test
-		Buffer.MAX_BUFFER_SIZE = 100;		
-		for(int i=0; i< Buffer.MAX_BUFFER_SIZE - Buffer.SMALL_BUFFER_SIZE; i++) {
-			b.append((byte)0x1);
+		
+		int initial_small_size = Buffer.SMALL_BUFFER_SIZE;
+		int initial_max_size = Buffer.MAX_BUFFER_SIZE;
+		try {
+			Buffer b = new Buffer();
+			Buffer.SMALL_BUFFER_SIZE = 20;		// to speed up the test
+			Buffer.MAX_BUFFER_SIZE = 100;		
+			for(int i=0; i< Buffer.MAX_BUFFER_SIZE - Buffer.SMALL_BUFFER_SIZE; i++) {
+				b.append((byte)0x1);
+			}
+		}
+		finally {
+			Buffer.SMALL_BUFFER_SIZE = initial_small_size;
+			Buffer.MAX_BUFFER_SIZE = initial_max_size;		
 		}
 	}
 


### PR DESCRIPTION
The unit test for issue #438 modifies important public static state in order to speed up test execution.
It reverts it back to the original values not to affect other unit tests running in the same JVM.