### PR TITLE
#446 DatagramServer.join()/leave() return Promise<Boolean>; fix UdpServe...

### DIFF
--- a/reactor-net/src/main/java/reactor/io/net/config/ServerSocketOptions.java
+++ b/reactor-net/src/main/java/reactor/io/net/config/ServerSocketOptions.java
@@ -16,6 +16,8 @@
 
 package reactor.io.net.config;
 
+import java.net.ProtocolFamily;
+
 /**
  * Encapsulates configuration options for server sockets.
  *
@@ -23,8 +25,10 @@ package reactor.io.net.config;
  */
 public class ServerSocketOptions extends CommonSocketOptions<ServerSocketOptions> {
 
-	private int     backlog   = 1000;
-	private boolean reuseAddr = true;
+	private int     		backlog   		= 1000;
+	private boolean 		reuseAddr 		= true;
+	private ProtocolFamily 	protocolFamily 	= null;
+
 
 	/**
 	 * Returns the configured pending connection backlog for the socket.
@@ -65,6 +69,25 @@ public class ServerSocketOptions extends CommonSocketOptions<ServerSocketOptions
 	 */
 	public ServerSocketOptions reuseAddr(boolean reuseAddr) {
 		this.reuseAddr = reuseAddr;
+		return this;
+	}
+
+	/**
+	 * Returns the configured protocol family for the socket.
+	 *
+	 * @return the configured protocol family for the socket
+	 */
+	public ProtocolFamily protocolFamily() { return protocolFamily; }
+
+	/**
+	 * Configures the protocol family for the socket.
+	 *
+	 * @param protocolFamily the protocol family for the socket, or null for the system default family
+	 *
+	 * @return {@code this}
+	 */
+	public ServerSocketOptions protocolFamily(ProtocolFamily protocolFamily) {
+		this.protocolFamily = protocolFamily;
 		return this;
 	}
 }

--- a/reactor-net/src/main/java/reactor/io/net/impl/netty/tcp/NettyTcpServer.java
+++ b/reactor-net/src/main/java/reactor/io/net/impl/netty/tcp/NettyTcpServer.java
@@ -21,6 +21,7 @@ import io.netty.buffer.PooledByteBufAllocator;
 import io.netty.channel.*;
 import io.netty.channel.nio.NioEventLoopGroup;
 import io.netty.channel.socket.SocketChannel;
+import io.netty.channel.socket.SocketChannelConfig;
 import io.netty.channel.socket.nio.NioServerSocketChannel;
 import io.netty.handler.logging.LoggingHandler;
 import io.netty.handler.ssl.SslHandler;
@@ -98,16 +99,22 @@ public class NettyTcpServer<IN, OUT> extends TcpServer<IN, OUT> {
 				.option(ChannelOption.SO_BACKLOG, options.backlog())
 				.option(ChannelOption.SO_RCVBUF, options.rcvbuf())
 				.option(ChannelOption.SO_SNDBUF, options.sndbuf())
-				.option(ChannelOption.SO_KEEPALIVE, options.keepAlive())
 				.option(ChannelOption.SO_REUSEADDR, options.reuseAddr())
-				.option(ChannelOption.SO_LINGER, options.linger())
-				.option(ChannelOption.TCP_NODELAY, options.tcpNoDelay())
 				.localAddress((null == listenAddress ? new InetSocketAddress(3000) : listenAddress))
 				.childOption(ChannelOption.ALLOCATOR, PooledByteBufAllocator.DEFAULT)
 				.childOption(ChannelOption.AUTO_READ, sslOptions != null)
 				.childHandler(new ChannelInitializer<SocketChannel>() {
 					@Override
 					public void initChannel(final SocketChannel ch) throws Exception {
+						SocketChannelConfig config = ch.config();
+						config.setReceiveBufferSize(options.rcvbuf());
+						config.setSendBufferSize(options.sndbuf());
+						config.setKeepAlive(options.keepAlive());
+						config.setReuseAddress(options.reuseAddr());
+						config.setSoLinger(options.linger());
+						config.setTcpNoDelay(options.tcpNoDelay());
+
+
 						if (log.isDebugEnabled()) {
 							log.debug("CONNECT {}", ch);
 						}

--- a/reactor-net/src/main/java/reactor/io/net/impl/netty/tcp/NettyTcpServer.java
+++ b/reactor-net/src/main/java/reactor/io/net/impl/netty/tcp/NettyTcpServer.java
@@ -21,7 +21,6 @@ import io.netty.buffer.PooledByteBufAllocator;
 import io.netty.channel.*;
 import io.netty.channel.nio.NioEventLoopGroup;
 import io.netty.channel.socket.SocketChannel;
-import io.netty.channel.socket.SocketChannelConfig;
 import io.netty.channel.socket.nio.NioServerSocketChannel;
 import io.netty.handler.logging.LoggingHandler;
 import io.netty.handler.ssl.SslHandler;
@@ -99,22 +98,16 @@ public class NettyTcpServer<IN, OUT> extends TcpServer<IN, OUT> {
 				.option(ChannelOption.SO_BACKLOG, options.backlog())
 				.option(ChannelOption.SO_RCVBUF, options.rcvbuf())
 				.option(ChannelOption.SO_SNDBUF, options.sndbuf())
+				.option(ChannelOption.SO_KEEPALIVE, options.keepAlive())
 				.option(ChannelOption.SO_REUSEADDR, options.reuseAddr())
+				.option(ChannelOption.SO_LINGER, options.linger())
+				.option(ChannelOption.TCP_NODELAY, options.tcpNoDelay())
 				.localAddress((null == listenAddress ? new InetSocketAddress(3000) : listenAddress))
 				.childOption(ChannelOption.ALLOCATOR, PooledByteBufAllocator.DEFAULT)
 				.childOption(ChannelOption.AUTO_READ, sslOptions != null)
 				.childHandler(new ChannelInitializer<SocketChannel>() {
 					@Override
 					public void initChannel(final SocketChannel ch) throws Exception {
-						SocketChannelConfig config = ch.config();
-						config.setReceiveBufferSize(options.rcvbuf());
-						config.setSendBufferSize(options.sndbuf());
-						config.setKeepAlive(options.keepAlive());
-						config.setReuseAddress(options.reuseAddr());
-						config.setSoLinger(options.linger());
-						config.setTcpNoDelay(options.tcpNoDelay());
-
-
 						if (log.isDebugEnabled()) {
 							log.debug("CONNECT {}", ch);
 						}

--- a/reactor-net/src/main/java/reactor/io/net/udp/DatagramServer.java
+++ b/reactor-net/src/main/java/reactor/io/net/udp/DatagramServer.java
@@ -68,9 +68,9 @@ public abstract class DatagramServer<IN, OUT>
 	}
 
 	/**
-	 * Start this server.
+	 * Start and bind this {@literal DatagramServer} to the configured listen port.
 	 *
-	 * @return {@literal this}
+	 * @return a {@link reactor.rx.Promise} that will be complete when the {@link DatagramServer} is started
 	 */
 	public abstract Promise<Boolean> start();
 
@@ -83,9 +83,9 @@ public abstract class DatagramServer<IN, OUT>
 	 * @param iface
 	 * 		interface to use for multicast
 	 *
-	 * @return {@literal this}
+	 * @return a {@link reactor.rx.Promise} that will be complete when the group has been joined
 	 */
-	public abstract Promise<Void> join(InetAddress multicastAddress, NetworkInterface iface);
+	public abstract Promise<Boolean> join(InetAddress multicastAddress, NetworkInterface iface);
 
 	/**
 	 * Join a multicast group.
@@ -93,9 +93,9 @@ public abstract class DatagramServer<IN, OUT>
 	 * @param multicastAddress
 	 * 		multicast address of the group to join
 	 *
-	 * @return {@literal this}
+	 * @return a {@link reactor.rx.Promise} that will be complete when the group has been joined
 	 */
-	public Promise<Void> join(InetAddress multicastAddress) {
+	public Promise<Boolean> join(InetAddress multicastAddress) {
 		return join(multicastAddress, null);
 	}
 
@@ -107,9 +107,9 @@ public abstract class DatagramServer<IN, OUT>
 	 * @param iface
 	 * 		interface to use for multicast
 	 *
-	 * @return {@literal this}
+	 * @return a {@link reactor.rx.Promise} that will be complete when the group has been left
 	 */
-	public abstract Promise<Void> leave(InetAddress multicastAddress, NetworkInterface iface);
+	public abstract Promise<Boolean> leave(InetAddress multicastAddress, NetworkInterface iface);
 
 	/**
 	 * Leave a multicast group.
@@ -117,9 +117,9 @@ public abstract class DatagramServer<IN, OUT>
 	 * @param multicastAddress
 	 * 		multicast address of the group to leave
 	 *
-	 * @return {@literal this}
+	 * @return a {@link reactor.rx.Promise} that will be complete when the group has been left
 	 */
-	public Promise<Void> leave(InetAddress multicastAddress) {
+	public Promise<Boolean> leave(InetAddress multicastAddress) {
 		return leave(multicastAddress, null);
 	}
 


### PR DESCRIPTION
See https://github.com/reactor/reactor/issues/446. This doesn't tackle the problem with void futures, but works around them by making `DatagramServer`.`join()`/`leave()` return `Promise<Boolean>`, consistent with the other asynchronous methods on this class.

At the same time I have:

* Fixed and reenabled the UdpServerTests 
* Removed duplicate channel configuration - setting Netty bootstrap options is sufficient
* Add ProtocolFamily server socket option - this is to get the multicast test to pass on a machine with IPv6 support. The Multicast test explicitly uses an IPv4 multicast address, so needs a IPv4 DatagramChannel.

