### PR TITLE
Add a getAvailableBacklog() getter to the ReactorProcessor to provide in...

### DIFF
--- a/reactor-core/src/main/java/reactor/core/processor/ReactorProcessor.java
+++ b/reactor-core/src/main/java/reactor/core/processor/ReactorProcessor.java
@@ -72,6 +72,8 @@ public abstract class ReactorProcessor<E> implements Processor<E, E>, Consumer<E
 		}
 		return false;
 	}
+	
+	public abstract long getAvailableCapacity();
 
 	/**
 	 * A Container for data passed on this processor

--- a/reactor-core/src/main/java/reactor/core/processor/RingBufferProcessor.java
+++ b/reactor-core/src/main/java/reactor/core/processor/RingBufferProcessor.java
@@ -15,17 +15,27 @@
  */
 package reactor.core.processor;
 
-import org.reactivestreams.Subscriber;
-import org.reactivestreams.Subscription;
-import reactor.core.support.NamedDaemonThreadFactory;
-import reactor.core.support.SpecificationExceptions;
-import reactor.jarjar.com.lmax.disruptor.*;
-import reactor.jarjar.com.lmax.disruptor.dsl.ProducerType;
-
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.locks.LockSupport;
+
+import org.reactivestreams.Subscriber;
+import org.reactivestreams.Subscription;
+
+import reactor.core.support.NamedDaemonThreadFactory;
+import reactor.core.support.SpecificationExceptions;
+import reactor.jarjar.com.lmax.disruptor.AlertException;
+import reactor.jarjar.com.lmax.disruptor.BlockingWaitStrategy;
+import reactor.jarjar.com.lmax.disruptor.EventFactory;
+import reactor.jarjar.com.lmax.disruptor.EventProcessor;
+import reactor.jarjar.com.lmax.disruptor.RingBuffer;
+import reactor.jarjar.com.lmax.disruptor.Sequence;
+import reactor.jarjar.com.lmax.disruptor.SequenceBarrier;
+import reactor.jarjar.com.lmax.disruptor.Sequencer;
+import reactor.jarjar.com.lmax.disruptor.TimeoutException;
+import reactor.jarjar.com.lmax.disruptor.WaitStrategy;
+import reactor.jarjar.com.lmax.disruptor.dsl.ProducerType;
 
 /**
  * An implementation of a RingBuffer backed message-passing Processor.
@@ -381,6 +391,11 @@ public final class RingBufferProcessor<E> extends ReactorProcessor<E> {
 				", barrier=" + barrier.getCursor() +
 				'}';
 	}
+	
+	@Override
+	public long getAvailableCapacity() {
+		return ringBuffer.remainingCapacity();
+	}	
 
 	private final class RingBufferSubscription implements Subscription {
 

--- a/reactor-core/src/main/java/reactor/core/processor/RingBufferWorkProcessor.java
+++ b/reactor-core/src/main/java/reactor/core/processor/RingBufferWorkProcessor.java
@@ -15,17 +15,26 @@
  */
 package reactor.core.processor;
 
-import org.reactivestreams.Subscriber;
-import org.reactivestreams.Subscription;
-import reactor.core.support.NamedDaemonThreadFactory;
-import reactor.core.support.SpecificationExceptions;
-import reactor.jarjar.com.lmax.disruptor.*;
-import reactor.jarjar.com.lmax.disruptor.dsl.ProducerType;
-
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.locks.LockSupport;
+
+import org.reactivestreams.Subscriber;
+import org.reactivestreams.Subscription;
+
+import reactor.core.support.NamedDaemonThreadFactory;
+import reactor.core.support.SpecificationExceptions;
+import reactor.jarjar.com.lmax.disruptor.AlertException;
+import reactor.jarjar.com.lmax.disruptor.BlockingWaitStrategy;
+import reactor.jarjar.com.lmax.disruptor.EventFactory;
+import reactor.jarjar.com.lmax.disruptor.EventProcessor;
+import reactor.jarjar.com.lmax.disruptor.RingBuffer;
+import reactor.jarjar.com.lmax.disruptor.Sequence;
+import reactor.jarjar.com.lmax.disruptor.SequenceBarrier;
+import reactor.jarjar.com.lmax.disruptor.Sequencer;
+import reactor.jarjar.com.lmax.disruptor.WaitStrategy;
+import reactor.jarjar.com.lmax.disruptor.dsl.ProducerType;
 
 /**
  * An implementation of a RingBuffer backed message-passing WorkProcessor.
@@ -385,7 +394,6 @@ public final class RingBufferWorkProcessor<E> extends ReactorProcessor<E> {
 		}
 
 		@Override
-		@SuppressWarnings("unchecked")
 		public void request(long n) {
 			if (n <= 0l) {
 				sub.onError(SpecificationExceptions.spec_3_09_exception(n));
@@ -576,4 +584,10 @@ public final class RingBufferWorkProcessor<E> extends ReactorProcessor<E> {
 			running.set(false);
 		}
 	}
+
+	@Override
+	public long getAvailableCapacity() {
+		return ringBuffer.remainingCapacity();
+	}	
+	
 }

--- a/reactor-core/src/test/java/reactor/core/processor/ReactorProcessorGettersTests.java
+++ b/reactor-core/src/test/java/reactor/core/processor/ReactorProcessorGettersTests.java
@@ -1,0 +1,36 @@
+package reactor.core.processor;
+
+import static org.junit.Assert.assertEquals;
+
+import org.junit.Test;
+
+/**
+ * @author Sergey Shcherbakov
+ */
+public class ReactorProcessorGettersTests {
+
+	@Test
+	public void testRingBufferProcessorGetters() {
+		
+		final int TEST_BUFFER_SIZE = 16;
+		ReactorProcessor<Object> processor = RingBufferProcessor.create("testProcessor", TEST_BUFFER_SIZE);
+		
+		assertEquals(TEST_BUFFER_SIZE, processor.getAvailableCapacity());
+		
+	}
+
+	@Test
+	public void testRingBufferWorkProcessorGetters() {
+		
+		final int TEST_BUFFER_SIZE = 16;
+		ReactorProcessor<Object> processor = RingBufferWorkProcessor.create("testProcessor", TEST_BUFFER_SIZE);
+		
+		assertEquals(TEST_BUFFER_SIZE, processor.getAvailableCapacity());
+		
+		processor.accept(new Object());
+		
+		assertEquals(TEST_BUFFER_SIZE - 1 , processor.getAvailableCapacity());
+
+	}
+	
+}


### PR DESCRIPTION
...sight into the ringBuffer state at runtime