### PR TITLE
Upgrade to compile against latest version of JSR 305 annotations

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -139,7 +139,7 @@ configure(allprojects) { project ->
   // dependencies that are common across all java projects
   dependencies {
     // JSR-305 annotations
-    optional "com.google.code.findbugs:jsr305:2.0.0"
+    optional "com.google.code.findbugs:jsr305:3.0.0"
 
     // Testing
     testCompile "org.codehaus.groovy:groovy:$groovyVersion",


### PR DESCRIPTION
Spring IO Platform 2.0, which will include Reactor 2.0, will use `com.google.code.findbugs:jsr305:3.0.0`. This PR aligns Reactor's build with the Platform.