### PR TITLE
- implementation for handling HTTP response status codes of 400 and 404

### DIFF
--- a/reactor-net/src/main/java/reactor/io/net/http/HttpException.java
+++ b/reactor-net/src/main/java/reactor/io/net/http/HttpException.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright (c) 2011-2015 Pivotal Software Inc, All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package reactor.io.net.http;
+
+import io.netty.handler.codec.http.HttpResponseStatus;
+
+/**
+ * An exception for signalling that an error occurred during a communication over HTTP protocol
+ *
+ * @author Anatoly Kadyshev
+ */
+public class HttpException extends Exception {
+
+    private final HttpResponseStatus responseStatus;
+
+    public HttpException(HttpResponseStatus responseStatus) {
+        super("HTTP request failed with code: " + responseStatus.code());
+        this.responseStatus = responseStatus;
+    }
+
+    public HttpResponseStatus getResponseStatus() {
+        return responseStatus;
+    }
+}

--- a/reactor-net/src/main/java/reactor/io/net/impl/netty/NettyChannelHandlerBridge.java
+++ b/reactor-net/src/main/java/reactor/io/net/impl/netty/NettyChannelHandlerBridge.java
@@ -53,6 +53,11 @@ public class NettyChannelHandlerBridge<IN, OUT> extends ChannelDuplexHandler {
 	protected PushSubscription<IN> channelSubscription;
 	private   ByteBuf              remainder;
 
+	/**
+	 * The body of an HTTP response should be discarded.
+	 */
+	private boolean discardBody = false;
+
 	public NettyChannelHandlerBridge(
 			ReactorChannelHandler<IN, OUT, ChannelStream<IN, OUT>> handler, NettyChannelStream<IN, OUT> channelStream
 	) {
@@ -172,7 +177,7 @@ public class NettyChannelHandlerBridge<IN, OUT> extends ChannelDuplexHandler {
 	@SuppressWarnings("unchecked")
 	protected final void doRead(ChannelHandlerContext ctx, Object msg) {
 		try {
-			if (null == channelSubscription || msg == Unpooled.EMPTY_BUFFER) {
+			if (null == channelSubscription || msg == Unpooled.EMPTY_BUFFER	|| discardBody) {
 				ReferenceCountUtil.release(msg);
 				return;
 			}
@@ -509,5 +514,9 @@ public class NettyChannelHandlerBridge<IN, OUT> extends ChannelDuplexHandler {
 
 	public NettyChannelStream<IN, OUT> getChannelStream() {
 		return channelStream;
+	}
+
+	public void setDiscardBody(boolean discardBody) {
+		this.discardBody = discardBody;
 	}
 }

--- a/reactor-net/src/test/groovy/reactor/io/net/http/HttpResponseStatusCodesHandlingSpec.groovy
+++ b/reactor-net/src/test/groovy/reactor/io/net/http/HttpResponseStatusCodesHandlingSpec.groovy
@@ -1,0 +1,83 @@
+package reactor.io.net.http
+
+import reactor.Environment
+import reactor.io.codec.StandardCodecs
+import reactor.io.net.NetStreams
+import reactor.rx.Streams
+import spock.lang.Specification
+
+import java.util.concurrent.TimeUnit
+
+/**
+ * @author Anatoly Kadyshev
+ */
+public class HttpResponseStatusCodesHandlingSpec extends Specification {
+
+    Environment env
+
+    def setup() {
+        env = Environment.initializeIfEmpty().assignErrorJournal()
+    }
+
+    def "http status code 404 is handled by the client"() {
+        given: "a simple HttpServer"
+            def server = NetStreams.httpServer {
+                it.codec(StandardCodecs.STRING_CODEC).listen(0).dispatcher(Environment.sharedDispatcher())
+            }
+
+        when: "the server is prepared"
+            server.post('/test') { HttpChannel<String, String> req ->
+                req.writeWith(
+                        req.log('server-received')
+                )
+            }
+
+        then: "the server was started"
+            server?.start()?.awaitSuccess(5, TimeUnit.SECONDS)
+
+        when: "a request with unsupported URI is sent onto the server"
+            def client = NetStreams.httpClient {
+                it.codec(StandardCodecs.STRING_CODEC).connect("localhost", server.listenAddress.port)
+            }
+
+            def replyReceived = ""
+            def content = client.get('/unsupportedURI') { HttpChannel<String,String> req ->
+                //prepare content-type
+                req.header('Content-Type', 'text/plain')
+
+                //return a producing stream to send some data along the request
+                req.writeWith(
+                    Streams
+                            .just("Hello")
+                            .log('client-send')
+                )
+            }
+            .flatMap { replies ->
+                //successful request, listen for replies
+                replies
+                        .log('client-received')
+                        .consume { s ->
+                            replyReceived = s
+                        }
+            }
+            .onError {
+                //something failed during the request or the reply processing
+                println "Failed requesting server: $it"
+            }
+
+        then: "exception is thrown with a message and no reply received"
+            def exceptionMessage = ""
+
+            try {
+                content.await();
+            } catch (RuntimeException ex) {
+                exceptionMessage = ex.getCause().getMessage();
+            }
+
+            exceptionMessage == "HTTP request failed with code: 404"
+            replyReceived == ""
+
+        cleanup: "the client/server where stopped"
+            client?.shutdown()?.onComplete { server.shutdown() }?.awaitSuccess(5, TimeUnit.SECONDS)
+    }
+}


### PR DESCRIPTION
Iteration #1 of implementation for handling HTTP response status codes of 400 and 404 on the client side.

