### PR TITLE
- hanging of tests due to RingBufferDispatcher.awaitAndShutdown issue

### DIFF
--- a/reactor-core/src/test/java/reactor/core/dispatch/RingBufferDispatcherTest.java
+++ b/reactor-core/src/test/java/reactor/core/dispatch/RingBufferDispatcherTest.java
@@ -1,0 +1,18 @@
+package reactor.core.dispatch;
+
+import org.junit.Test;
+
+/**
+ * @author Anatoly Kadyshev
+ */
+public class RingBufferDispatcherTest {
+
+    @Test
+    public void testAwaitAndShutdownDoesNotHangForever() {
+        for (int i = 0; i < 1000; i++) {
+            RingBufferDispatcher dispatcher = new RingBufferDispatcher("dispatcher", 128);
+            dispatcher.awaitAndShutdown();
+        }
+    }
+
+}


### PR DESCRIPTION
The problem which is addressed here is indefinite hanging of StreamCombinationTests which takes place at the very first line (usually) of method after() provided below.
```java
	@After
	public void after(){
		sensorEven.getDispatcher().awaitAndShutdown();
		sensorOdd.getDispatcher().awaitAndShutdown();
	}
```
Basically, call to .awaitAndShutdown() never returns.

***The root cause:***
BatchEventProcessor from disruptor classes which processes events and blocks on BlockingWaitStrategy could be scheduled onto executor after disruptor.shutdown() method has been called. 
As a result BatchEventProcessor resets its sequenceBarrier alert flag and blocks on a lock condition within BlockingWaitStrategy.
This prevents executor.awaitTermination(timeout, TimeUnit) method to return.

***The corresponding build***
https://drone.io/github.com/kadyana/reactor/33