### PR TITLE
2 way SSL handshake: Enable Tcp Servers to perform certificate authen…

### DIFF
--- a/reactor-net/src/main/java/reactor/io/net/tcp/ssl/SSLEngineSupplier.java
+++ b/reactor-net/src/main/java/reactor/io/net/tcp/ssl/SSLEngineSupplier.java
@@ -60,6 +60,10 @@ public class SSLEngineSupplier implements Supplier<SSLEngine> {
 
 		ssl = ctx.createSSLEngine();
 		ssl.setUseClientMode(client);
+
+		if (!client && null != sslOpts.trustManagers()) {
+			ssl.setNeedClientAuth(true);
+		}
 	}
 
 	@Override


### PR DESCRIPTION
If the option ssl.setNeedClientAuth(true) is not set, the trustmanagers defined on SSLOptions for TcpServers aren't called.

The workaround is to define a huge NettyServerSocketOptions().pipelineConfigurer(..) and redefine all SSLContext /TrustManagerFactory / KeyManagerFactory logic.