### PR TITLE
Fixes return type of EventBus.getConsumerRegistry()

### DIFF
--- a/reactor-bus/src/main/java/reactor/bus/EventBus.java
+++ b/reactor-bus/src/main/java/reactor/bus/EventBus.java
@@ -257,7 +257,7 @@ public class EventBus implements Bus<Event<?>>, Consumer<Event<?>> {
 	 *
 	 * @return The {@link Registry} in use.
 	 */
-	public Registry<?, Consumer<? extends Event<?>>> getConsumerRegistry() {
+	public Registry<Object, Consumer<? extends Event<?>>> getConsumerRegistry() {
 		return consumerRegistry;
 	}
 


### PR DESCRIPTION
fixes oversight in https://github.com/reactor/reactor/commit/0b06eb338c657df693e62b1d1eb51a98d5769e78 which requires all users of `getConsumerRegistry()` to cast it to `(Registry<Object, Consumer<? extends Event<?>>>) eventBus.getConsumerRegistry()`

This matches the internally used type.