### PR TITLE
Upgrade to JsonPath 2.0

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -34,7 +34,7 @@ ext {
   nettyVersion = '4.0.27.Final'
   jeromqVersion = '0.3.4'
   jacksonDatabindVersion = '2.5.1'
-  jsonPathVersion = '1.2.0'
+  jsonPathVersion = '2.0.0'
   kryoVersion = '2.24.0'
   protobufVersion = '2.6.1'
   snappyVersion = '1.1.1.6'

--- a/reactor-bus/src/main/java/reactor/bus/selector/JsonPathSelector.java
+++ b/reactor-bus/src/main/java/reactor/bus/selector/JsonPathSelector.java
@@ -24,6 +24,7 @@ import com.fasterxml.jackson.databind.node.ObjectNode;
 import com.jayway.jsonpath.*;
 import com.jayway.jsonpath.spi.json.JsonProvider;
 import com.jayway.jsonpath.spi.mapper.MappingProvider;
+
 import reactor.io.buffer.Buffer;
 
 import java.io.IOException;
@@ -269,6 +270,15 @@ public class JsonPathSelector extends ObjectSelector<Object, JsonPath> {
 				((ArrayNode) obj).set(idx, (JsonNode) value);
 			} else {
 				setProperty(mapper.convertValue(obj, JsonNode.class), key, value);
+			}
+		}
+
+		@Override
+		public Object unwrap(Object object) {
+			if (object instanceof JsonNode) {
+				return unwrap((JsonNode) object);
+			} else {
+				return object;
 			}
 		}
 


### PR DESCRIPTION
Spring Framework 4.2 and Spring Integration 4.2 are both now building against JsonPath 2.0. This PR aligns Reactor with those projects and implements JsonProvider’s new `unwrap(Object)` method.