### PR TITLE
Various Buffer capacity fixes

### DIFF
--- a/reactor-core/src/test/groovy/reactor/io/buffer/BufferSpec.groovy
+++ b/reactor-core/src/test/groovy/reactor/io/buffer/BufferSpec.groovy
@@ -426,4 +426,53 @@ class BufferSpec extends Specification {
 		pos == -1
 	}
 
+    def "A dynamic Buffer with no initial size can be expanded"() {
+        given: "A dynamic Buffer without param"
+        def buffer = new Buffer()
+        def originalCapacity = buffer.capacity()
+
+        when: "the Buffer is appended with 30 bytes"
+        int dataSize = 30
+        buffer.append(new byte[dataSize])
+
+        then: "the capacity has not changed"
+        buffer.capacity() == originalCapacity
+        buffer.position() == dataSize
+    }
+
+    def "A dynamic Buffer can be expanded"() {
+        given: "A dynamic Buffer starting with 32 kb"
+        def originalCapacity = 32 * 1024
+        def buffer = new Buffer(originalCapacity, false)
+
+        expect: "the capacity is equals to originalCapacity"
+        buffer.capacity() == originalCapacity
+
+        when: "the Buffer is appended with 4 kb"
+        int dataSize = 4 * 1024
+        buffer.append(new byte[dataSize])
+
+        then: "the capacity has not changed"
+        buffer.capacity() == originalCapacity
+        buffer.position() == dataSize
+
+        when: "the Buffer is appended with 64 kb"
+        dataSize = 64 * 1024
+        buffer.append(new byte[dataSize])
+
+        then: "the capacity should now be higher than original capacity"
+        buffer.capacity() >= originalCapacity
+    }
+
+    def "A fixed Buffer cannot be expanded"() {
+        given: "A fixed Buffer with 8 kb"
+        def buffer = new Buffer(8 * 1024, true)
+
+        when: "the Buffer is appended with 24 kb"
+        int dataSize = 24 * 1024
+        buffer.append(new byte[dataSize])
+
+        then: "a BufferOverflowException is thrown"
+        thrown(BufferOverflowException)
+    }
 }


### PR DESCRIPTION
While using TcpServer / TcpClient, I encountered some problems related to Buffer expansion (the Codecs can handle requests containing from few hundreds bytes to several kb).
The fixes were originally made for reactor 1.0.x and are currently used in production. This PR is targeted to master.

Hope this helps.
Guillaume