### PR TITLE
Use the latest version of the Spring IO Plugin

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -58,11 +58,10 @@ ext {
 buildscript {
   repositories {
     maven { url "http://repo.spring.io/plugins-release" }
-    jcenter()
   }
   dependencies {
     classpath 'org.springframework.build.gradle:propdeps-plugin:0.0.7',
-        'org.springframework.build.gradle:spring-io-plugin:0.0.3.RELEASE',
+        'io.spring.gradle:spring-io-plugin:0.0.4.RELEASE',
         'com.github.jengelman.gradle.plugins:shadow:1.2.0'
   }
 }
@@ -169,8 +168,12 @@ configure(subprojects) { subproject ->
       maven { url 'http://repo.spring.io/libs-snapshot' }
     }
 
-    dependencies {
-      springIoVersions "io.spring.platform:platform-versions:$platformVersion@properties"
+    dependencyManagement {
+      springIoTestRuntime {
+        imports {
+          mavenBom "io.spring.platform:platform-bom:$platformVersion"
+        }
+      }
     }
   }
 }


### PR DESCRIPTION
This change is necessary to allow Spring IO Platform 2.0 to remove the platform-versions properties file that was deprecated in 1.1. To allow Reactor's Platform compliance to be verified as part of Spring IO Platform 2.0's build and release process, I'd like this to be included in Reactor 2.0.x which is the version that's currently in Spring IO Platform 2.0. If you have any questions, please let me know.