### PR TITLE
Add Pair class

### DIFF
--- a/reactor-core/src/main/java/reactor/fn/pair/Pair.java
+++ b/reactor-core/src/main/java/reactor/fn/pair/Pair.java
@@ -1,0 +1,39 @@
+package reactor.fn.pair;
+
+/**
+ * A {@literal Pair} pair of objects, each of which can be of an arbitrary type.
+ *
+ * @author Oleksandr Petrov
+ */
+public class Pair<K, V> {
+
+  private final K first;
+  private final V second;
+
+  /**
+   * Create a {@code Tap}.
+   * @param first the first object in the {@literal Pair}
+   * @param second the second object in the {@literal Pair}
+   */
+  public Pair(K first,
+              V second) {
+    this.first = first;
+    this.second = second;
+  }
+
+  /**
+   * Get the value of the first object in the {@literal Pair}
+   * @return the first object
+   */
+  public K getFirst() {
+    return first;
+  }
+
+  /**
+   * Get the value of the second object in the {@literal Pair}
+   * @return the second object
+   */
+  public V getSecond() {
+    return second;
+  }
+}


### PR DESCRIPTION
Pair class would be a good addition to currently existing Tuple. 

Thing with tuple is that it's an array lookup and it's constructed from the array and works with the raw types.

For tight integration with systems like Kafka (or anything that can serve as a Publisher of Pairs), it's necessary to have a possiblity of directly creating (without creating a wrapper array) a Pair.