### PR TITLE
Default value updates for timeout and linger in CommonSocketOptions

### DIFF
--- a/reactor-net/src/main/java/reactor/io/net/config/CommonSocketOptions.java
+++ b/reactor-net/src/main/java/reactor/io/net/config/CommonSocketOptions.java
@@ -28,9 +28,9 @@ import reactor.io.buffer.Buffer;
 @SuppressWarnings("unchecked")
 public abstract class CommonSocketOptions<SO extends CommonSocketOptions<? super SO>> {
 
-	private int     timeout    = 30000;
+	private int     timeout    = 5000; // value in millis
 	private boolean keepAlive  = true;
-	private int     linger     = 30000;
+	private int     linger     = 2; // value in seconds
 	private boolean tcpNoDelay = true;
 	private int     rcvbuf     = Buffer.SMALL_BUFFER_SIZE;
 	private int     sndbuf     = Buffer.SMALL_BUFFER_SIZE;


### PR DESCRIPTION
The linger value is in second, so 30000 was probably a copy-paste mistake.
I set it to 2, as it seems a reasonable default. The JDK has a negative value, which makes SO_LINGER disabled. Maybe keeping the JDK default could be an even more reasonable default, but I'm not a TCP expert.
The timeout value is reduced to 5 seconds, as it is used as connection establishment timeout, and this seems far enough for a library targeting high throughput. 

Hope this helps,
Guillaume