### PR TITLE
Fix inconsistent getter/setter types for backlog parameter

### DIFF
--- a/reactor-logback/src/main/java/reactor/logback/AsyncAppender.java
+++ b/reactor-logback/src/main/java/reactor/logback/AsyncAppender.java
@@ -56,7 +56,7 @@ public class AsyncAppender
 	private boolean includeCallerData = false;
 	private boolean started           = false;
 
-	public long getBacklog() {
+	public int getBacklog() {
 		return backlog;
 	}
 


### PR DESCRIPTION
The "backlog" parameter getter returns `long` instead of `int`, which makes it impossible to configure the appender in Logback's configuration file (the parser gets confused).

Example:
```
<appender name="ASYNC_FILE" class="reactor.logback.AsyncAppender">
	<param name="backlog" value="1024"/>
	<appender-ref ref="FILE"/>
</appender>
```