### PR TITLE
Iterator Publisher

### DIFF
--- a/reactor-core/src/main/java/reactor/core/publisher/AbstractIteratorSequencer.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/AbstractIteratorSequencer.java
@@ -1,0 +1,22 @@
+package reactor.core.publisher;
+
+import reactor.core.subscriber.SubscriberWithContext;
+import reactor.fn.Consumer;
+
+import java.util.Iterator;
+
+public abstract class AbstractIteratorSequencer<T>
+        implements Consumer<SubscriberWithContext<T, Iterator<? extends T>>> {
+
+    @Override
+    public final void accept(SubscriberWithContext<T, Iterator<? extends T>> subscriber) {
+        final Iterator<? extends T> iterator = subscriber.context();
+        if (iterator.hasNext()) {
+            subscriber.onNext(iterator.next());
+        }
+        else {
+            subscriber.onComplete();
+        }
+    }
+
+}

--- a/reactor-core/src/main/java/reactor/core/publisher/IterableSequencer.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/IterableSequencer.java
@@ -26,12 +26,12 @@ import java.util.Iterator;
 
 //
 
-public final class IteratorSequencer<T> extends AbstractIteratorSequencer<T>
+public final class IterableSequencer<T> extends AbstractIteratorSequencer<T>
         implements Function<Subscriber<? super T>, Iterator<? extends T>> {
 
-    private final Iterator<? extends T> defaultValues;
+    private final Iterable<? extends T> defaultValues;
 
-    public IteratorSequencer(Iterator<? extends T> defaultValues) {
+    public IterableSequencer(Iterable<? extends T> defaultValues) {
         this.defaultValues = defaultValues;
     }
 
@@ -40,7 +40,7 @@ public final class IteratorSequencer<T> extends AbstractIteratorSequencer<T>
         if (defaultValues == null) {
             throw PublisherFactory.PrematureCompleteException.INSTANCE;
         }
-        Iterator<? extends T> it = defaultValues;
+        Iterator<? extends T> it = defaultValues.iterator();
         if (!it.hasNext()) {
             throw PublisherFactory.PrematureCompleteException.INSTANCE;
         }
@@ -49,6 +49,6 @@ public final class IteratorSequencer<T> extends AbstractIteratorSequencer<T>
 
     @Override
     public String toString() {
-        return "iterator=" + defaultValues;
+        return "iterable=" + defaultValues;
     }
 }

--- a/reactor-stream/src/main/java/reactor/rx/Streams.java
+++ b/reactor-stream/src/main/java/reactor/rx/Streams.java
@@ -16,14 +16,6 @@
 
 package reactor.rx;
 
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.List;
-import java.util.concurrent.CountDownLatch;
-import java.util.concurrent.Future;
-import java.util.concurrent.TimeUnit;
-import java.util.concurrent.atomic.AtomicReference;
-
 import org.reactivestreams.Processor;
 import org.reactivestreams.Publisher;
 import org.reactivestreams.Subscriber;
@@ -65,6 +57,15 @@ import reactor.rx.stream.SingleTimerStream;
 import reactor.rx.stream.SingleValueStream;
 import reactor.rx.stream.StreamOperator;
 import reactor.rx.stream.SupplierStream;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Iterator;
+import java.util.List;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicReference;
 
 /**
  * A public factory to build {@link Stream}, Streams provide for common transformations from a few structures such as
@@ -331,6 +332,19 @@ public class Streams {
 	 * @return a {@link Stream} based on the given values
 	 */
 	public static <T> Stream<T> from(Iterable<? extends T> values) {
+		return Streams.wrap(Publishers.from(values));
+	}
+
+	/**
+	 * Build a {@literal Stream} whom data is sourced by each element of the passed iterator on subscription request.
+	 * <p>
+	 * It will use the passed dispatcher to emit signals.
+	 *
+	 * @param values The values to {@code onNext()}
+	 * @param <T>    type of the values
+	 * @return a {@link Stream} based on the given values
+	 */
+	public static <T> Stream<T> from(Iterator<? extends T> values) {
 		return Streams.wrap(Publishers.from(values));
 	}
 


### PR DESCRIPTION
Previously, only an `Iterable` and not an `Iterator` could be used as a publisher.  As the `Iterable` was used to call `.iterator()` there should have been an equivalent for passing in the `Iterator` directly.  This
change abstracts a common class for the actual iteration while creating separate child classes for initializing the context from an `Iterable` and `Iterator`.  It also adds `from()` and `convert()` behavior
to `Publishers` as well as `from()` behavior to `Streams`.