### PR TITLE
Leave only one Error Handler to simplify API.

### DIFF
--- a/reactor-bus/src/main/java/reactor/bus/EventBus.java
+++ b/reactor-bus/src/main/java/reactor/bus/EventBus.java
@@ -150,20 +150,18 @@ public class EventBus extends AbstractBus<Object, Event<?>> implements Consumer<
 	public EventBus(@Nullable Processor<Event<?>, Event<?>> processor,
 	                int concurrency,
 	                @Nullable Router router) {
-		this(processor, concurrency, router, null, null);
+		this(processor, concurrency, router, null);
 	}
 
 	public EventBus(@Nullable Processor<Event<?>, Event<?>> processor,
 	                int concurrency,
 	                @Nullable Router router,
-	                @Nullable Consumer<Throwable> processorErrorHandler,
-	                @Nullable final Consumer<Throwable> uncaughtErrorHandler) {
+	                @Nullable Consumer<Throwable> processorErrorHandler) {
 		this(Registries.<Object, BiConsumer<Object, ? extends Event<?>>>create(),
 		  processor,
 		  concurrency,
 		  router,
-		  processorErrorHandler,
-		  uncaughtErrorHandler);
+		  processorErrorHandler);
 	}
 
 	/**
@@ -185,16 +183,13 @@ public class EventBus extends AbstractBus<Object, Event<?>> implements Consumer<
 	 *                              conversion will be used.
 	 * @param processorErrorHandler The {@link Consumer} to be used on {@link Processor} exceptions. May be {@code null}
 	 *                              in which case exceptions will be routed to this {@link EventBus} by it's class.
-	 * @param uncaughtErrorHandler  Default {@link Consumer} to be used on all uncaught exceptions. May be {@code null}
-	 *                              in which case exceptions will be logged.
 	 */
 	@SuppressWarnings("unchecked")
 	public EventBus(@Nonnull final Registry<Object, BiConsumer<Object, ? extends Event<?>>> consumerRegistry,
 	                @Nullable Processor<Event<?>, Event<?>> processor,
 	                int concurrency,
 	                @Nullable final Router router,
-					@Nullable Consumer<Throwable> processorErrorHandler,
-	                @Nullable final Consumer<Throwable> uncaughtErrorHandler) {
+					@Nullable Consumer<Throwable> processorErrorHandler) {
 		super(consumerRegistry,
 					concurrency,
 					router,
@@ -208,8 +203,7 @@ public class EventBus extends AbstractBus<Object, Event<?>> implements Consumer<
 													   null,
 													   null);
 						}
-					},
-					uncaughtErrorHandler);
+					});
 
 		Assert.notNull(consumerRegistry, "Consumer Registry cannot be null.");
 		this.processor = processor;
@@ -225,19 +219,6 @@ public class EventBus extends AbstractBus<Object, Event<?>> implements Consumer<
 			}
 			processor.onSubscribe(SignalType.NOOP_SUBSCRIPTION);
 		}
-
-		this.on(new ClassSelector(Throwable.class), new Consumer<Event<Throwable>>() {
-			final Logger log = LoggerFactory.getLogger(EventBus.class);
-
-			@Override
-			public void accept(Event<Throwable> ev) {
-				if (null == uncaughtErrorHandler) {
-					log.error(ev.getData().getMessage(), ev.getData());
-				} else {
-					uncaughtErrorHandler.accept(ev.getData());
-				}
-			}
-		});
 	}
 
 	/**

--- a/reactor-bus/src/main/java/reactor/bus/spec/EventRoutingComponentSpec.java
+++ b/reactor-bus/src/main/java/reactor/bus/spec/EventRoutingComponentSpec.java
@@ -47,7 +47,6 @@ public abstract class EventRoutingComponentSpec<SPEC extends EventRoutingCompone
 	private Router                                                   router;
 	private Filter                                                   eventFilter;
 	private Consumer<Throwable>                                      dispatchErrorHandler;
-	private Consumer<Throwable>                                      uncaughtErrorHandler;
 	private Registry<Object, BiConsumer<Object, ? extends Event<?>>> consumerRegistry;
 	private boolean traceEventPath = false;
 
@@ -132,19 +131,6 @@ public abstract class EventRoutingComponentSpec<SPEC extends EventRoutingCompone
 	}
 
 	/**
-	 * Configures the component's uncaught error handler for any errors that get reported into this component but
-	 * aren't a
-	 * direct result of dispatching (e.g. errors that originate from another component).
-	 *
-	 * @param uncaughtErrorHandler the error handler for uncaught errors
-	 * @return {@code this}
-	 */
-	public SPEC uncaughtErrorHandler(Consumer<Throwable> uncaughtErrorHandler) {
-		this.uncaughtErrorHandler = uncaughtErrorHandler;
-		return (SPEC) this;
-	}
-
-	/**
 	 * Configures this component to provide event tracing when dispatching and routing an event.
 	 *
 	 * @return {@code this}
@@ -203,8 +189,7 @@ public abstract class EventRoutingComponentSpec<SPEC extends EventRoutingCompone
 		  processor,
 		  concurrency,
 		  (router != null ? router : createEventRouter()),
-		  dispatchErrorHandler,
-		  uncaughtErrorHandler);
+		  dispatchErrorHandler);
 	}
 
 	private Router createEventRouter() {

--- a/reactor-bus/src/test/groovy/reactor/bus/EventBusSpec.groovy
+++ b/reactor-bus/src/test/groovy/reactor/bus/EventBusSpec.groovy
@@ -427,7 +427,6 @@ class EventBusSpec extends Specification {
 			def r = EventBus.config().
 					sync().
 					dispatchErrorHandler(consumer { t -> count++ }).
-					uncaughtErrorHandler(consumer { t -> count++ }).
 					get()
 			r.on $('test'), consumer { ev -> throw new Exception("error") }
 


### PR DESCRIPTION
+ Make logger singleton instance.

Do you think the default behaviour is good? We could for example both log _and_ route to class by default. Or just log. 

However in my experience just logging is the best thing to do, so I would personally even not route to Throwable... But let's talk about it :)