### PR TITLE
Use explicit casts to allow development with Eclipse

### DIFF
--- a/reactor-stream/src/test/java/reactor/reactivestreams/tck/AbstractStreamVerification.java
+++ b/reactor-stream/src/test/java/reactor/reactivestreams/tck/AbstractStreamVerification.java
@@ -106,7 +106,7 @@ public abstract class AbstractStreamVerification extends org.reactivestreams.tck
 
 	public abstract Processor<Integer, Integer> createProcessor(int bufferSize);
 
-	protected void monitorThreadUse(int val) {
+	protected void monitorThreadUse(Object val) {
 		AtomicLong counter = counters.get(Thread.currentThread());
 		if (counter == null) {
 			counter = new AtomicLong();

--- a/reactor-stream/src/test/java/reactor/reactivestreams/tck/StreamAndProcessorGroupTests.java
+++ b/reactor-stream/src/test/java/reactor/reactivestreams/tck/StreamAndProcessorGroupTests.java
@@ -23,6 +23,7 @@ import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
 import reactor.Processors;
 import reactor.core.processor.ProcessorGroup;
+import reactor.fn.BiFunction;
 import reactor.rx.Stream;
 import reactor.rx.Streams;
 import reactor.rx.action.StreamProcessor;
@@ -47,6 +48,7 @@ public class StreamAndProcessorGroupTests extends AbstractStreamVerification {
 				Processors.asyncGroup("stream-p-tck", bufferSize, 2,
 						Throwable::printStackTrace);
 
+		BiFunction<Integer, String, Integer> combinator = (t1, t2) -> t1;
 		return Broadcaster.<Integer>create(true)
 				.dispatchOn(sharedGroup)
 		                  .partition(2)
@@ -59,8 +61,7 @@ public class StreamAndProcessorGroupTests extends AbstractStreamVerification {
 		                                           .map(integer -> -integer)
 		                                           .buffer(batch, 50, TimeUnit.MILLISECONDS)
 		                                           .<Integer>split()
-		                                           .flatMap(i -> Streams.zip(Streams.just(i), otherStream, (t1, t2) ->
-				                                           t1))
+		                                           .flatMap(i -> Streams.zip(Streams.just(i), otherStream, combinator))
 
 				.dispatchOn(sharedGroup))
 				.when(Throwable.class, Throwable::printStackTrace)

--- a/reactor-stream/src/test/java/reactor/reactivestreams/tck/StreamAndProcessorTests.java
+++ b/reactor-stream/src/test/java/reactor/reactivestreams/tck/StreamAndProcessorTests.java
@@ -23,6 +23,7 @@ import org.junit.Test;
 import org.reactivestreams.Processor;
 import org.testng.SkipException;
 import reactor.Processors;
+import reactor.fn.BiFunction;
 import reactor.fn.tuple.Tuple1;
 import reactor.rx.Stream;
 import reactor.rx.Streams;
@@ -47,6 +48,7 @@ public class StreamAndProcessorTests extends AbstractStreamVerification {
 		cumulated.set(0);
 		cumulatedJoin.set(0);
 
+		BiFunction<Integer, String, Integer> combinator = (t1, t2) -> t1;
 		return Processors.create(p, Streams.wrap(p)
 		                                   .forkJoin(2, stream -> stream.scan((prev, next) -> next)
 		                                                                .map(integer -> -integer)
@@ -57,7 +59,8 @@ public class StreamAndProcessorTests extends AbstractStreamVerification {
 		                                                                .<Integer>split()
 		                                                                .observe(array -> cumulated.getAndIncrement())
 		                                                                .flatMap(i -> Streams.zip(Streams.just(i),
-				                                                                otherStream, (t1, t2) -> t1))
+		                                                                                          otherStream,
+		                                                                                          combinator))
 		                                                                .observe(this::monitorThreadUse))
 		                                   .observe(array -> cumulatedJoin.getAndIncrement())
 		                                   .process(Processors.topic("stream-raw-join", bufferSize))


### PR DESCRIPTION
Some of the generic types cannot be validated by Eclipse or can be
validated, but require configuration. Since there are only a few places
in reactor which use implicit casts, it is easy to make them explicit
and thus allow usage of Eclipse as an IDE for contributors.