### PR TITLE
Define whitespace settings

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,16 @@
+root = true
+
+[*]
+end_of_line = lf
+insert_final_newline = true
+trim_trailing_whitespace = true
+charset = utf-8
+indent_style = space
+indent_size = 2
+
+[*.{java,gradle}]
+indent_style = tab
+tab_width = 2
+
+[*.properties]
+charset = latin1


### PR DESCRIPTION
A central whitespace definition file makes it easier to get started
with the project. By defining it via editorconfig, editors and IDEs can
automatically pick up the settings and reconfigure themselves so that
the right settings are automatically used.