### PR TITLE
Avoid implicit casting in ProcessorGroup

### DIFF
--- a/reactor-core/src/main/java/reactor/core/processor/ProcessorGroup.java
+++ b/reactor-core/src/main/java/reactor/core/processor/ProcessorGroup.java
@@ -278,7 +278,7 @@ public class ProcessorGroup<T> implements Supplier<Processor<T, T>>, ReactiveSta
 			return (BiConsumer<V, Consumer<? super V>>) SYNC_DATA_DISPATCHER;
 		}
 
-		return (BiConsumer<V, Consumer<? super V>>) createBarrier(false);
+		return createBarrier(false);
 	}
 
 	/**
@@ -468,8 +468,7 @@ public class ProcessorGroup<T> implements Supplier<Processor<T, T>>, ReactiveSta
 		REF_COUNT.incrementAndGet(this);
 	}
 
-	@SuppressWarnings("unchecked")
-	private ProcessorBarrier<T> createBarrier(boolean forceWork) {
+	private <Y> ProcessorBarrier<Y> createBarrier(boolean forceWork) {
 
 		if (processor == null) {
 			return new SyncProcessorBarrier<>(this);


### PR DESCRIPTION
ProcessorGroup#createBarrier creates ProcessorBarriers using the generic
type T. This type is not always desired, e.g. when creating dispatchers
for other types. Casts can easily be avoided and thus problems with the
Eclipse compiler by adding a new generic type to
ProcessorGroup#createBarrier.

This is a follow up to PR 587 [1].

[1] https://github.com/reactor/reactor/pull/587