### PR TITLE
Consolidate Promise API and enable Eclipse dev

### DIFF
--- a/reactor-stream/src/main/java/reactor/rx/Promise.java
+++ b/reactor-stream/src/main/java/reactor/rx/Promise.java
@@ -234,7 +234,7 @@ public class Promise<O>
 	 * @param transformation the function to apply on signal to the transformed Promise
 	 * @return {@literal the new Promise}
 	 */
-	public final <V> Promise<V> map(@Nonnull final Function<? super O, V> transformation) {
+	public final <V> Promise<V> map(@Nonnull final Function<? super O, ? extends V> transformation) {
 		lock.lock();
 		try {
 			if (finalState == FinalState.ERROR) {

--- a/reactor-stream/src/main/java/reactor/rx/Promise.java
+++ b/reactor-stream/src/main/java/reactor/rx/Promise.java
@@ -251,7 +251,7 @@ public class Promise<O>
 		finally {
 			lock.unlock();
 		}
-		return stream().map(transformation).next();
+		return (Promise<V>) stream().map(transformation).next();
 	}
 
 	/**
@@ -288,7 +288,7 @@ public class Promise<O>
 		finally {
 			lock.unlock();
 		}
-		return stream().flatMap(transformation).next();
+		return (Promise<V>) stream().flatMap(transformation).next();
 
 	}
 


### PR DESCRIPTION
This is a PR containing two separate changes which can be discussed together as they are strongly related.

```
    Align Promise#map with Stream#map API

    Promise#map accepts a different type of transformations than Stream#map.
    This is just a minor API inconsistency. Given the fact that Stream#map
    accepts a wider range of transformation functions, this is  a backwards
    compatible change.
```

and

```
    Use explicit casts in Promise to allow Eclipse usage

    Many places in reactor do not require explicit casts since casting is
    done implicitly via generic usage. For instance, `Stream#map` accepts
    transformation functions of type `? extends V`, but types the
    `MapOperator` via generics to `V`.

    This is not yet done in `Promise#map` or `Promise#flatMap`. While the
    current solution works fine due to implicit casting, the Eclipse
    compiler has problems with this approach. Making these two casts
    explicit is the last step to enable development on the reactor project
    with the Eclipse IDE.
```