### PR TITLE
Reduce an amount of loggers for Bus.

### DIFF
--- a/reactor-bus/src/main/java/reactor/bus/AbstractBus.java
+++ b/reactor-bus/src/main/java/reactor/bus/AbstractBus.java
@@ -65,7 +65,6 @@ public abstract class AbstractBus<K, V> implements Bus<K, V>, ReactiveState.Link
   private final Registry<K, BiConsumer<K, ? extends V>> consumerRegistry;
   private final Router                                  router;
   private final Consumer<Throwable>                     processorErrorHandler;
-  private final Consumer<Throwable>                     uncaughtErrorHandler;
   private final int                                     concurrency;
 
   private volatile UUID id;
@@ -86,37 +85,30 @@ public abstract class AbstractBus<K, V> implements Bus<K, V>, ReactiveState.Link
    *                              Selector#matches(Object) match} the notification key and does not perform any type
    *                              conversion will be used.
    * @param processorErrorHandler The {@link Consumer} to be used on {@link Processor} exceptions. May be {@code null}
-   *                              in which case exceptions will be delegated to {@code uncaughtErrorHandler}.
-   * @param uncaughtErrorHandler  Default {@link Consumer} to be used on all uncaught exceptions. May be {@code null}
-   *                              in which case exceptions will be logged.
+   *                              in which case exceptions will be delegated to `{@code uncaughtErrorHandler}.
+   *
    */
   @SuppressWarnings("unchecked")
   public AbstractBus(@Nonnull Registry<K, BiConsumer<K, ? extends V>> consumerRegistry,
                      int concurrency,
                      @Nullable Router router,
-                     @Nullable Consumer<Throwable> processorErrorHandler,
-                     @Nullable final Consumer<Throwable> uncaughtErrorHandler) {
+                     @Nullable Consumer<Throwable> processorErrorHandler) {
     Assert.notNull(consumerRegistry, "Consumer Registry cannot be null.");
     this.consumerRegistry = consumerRegistry;
     this.concurrency = concurrency;
     this.router = (null == router ? DEFAULT_EVENT_ROUTER : router);
     if (null == processorErrorHandler) {
       this.processorErrorHandler = new Consumer<Throwable>() {
+        final Logger log = Logger.getLogger(AbstractBus.class);
+
         @Override
         public void accept(Throwable t) {
-          if (uncaughtErrorHandler == null) {
-            final Logger log = Logger.getLogger(AbstractBus.class);
-            log.error(t.getMessage(), t);
-          } else {
-            uncaughtErrorHandler.accept(t);
-          }
+          log.error(t.getMessage(), t);
         }
       };
     } else {
       this.processorErrorHandler = processorErrorHandler;
     }
-
-    this.uncaughtErrorHandler = uncaughtErrorHandler;
   }
 
   /**
@@ -158,15 +150,6 @@ public abstract class AbstractBus<K, V> implements Bus<K, V>, ReactiveState.Link
    */
   public Consumer<Throwable> getProcessorErrorHandler() {
     return processorErrorHandler;
-  }
-
-  /**
-   * Get the {@link Consumer<Throwable>} uncaught error handler
-   *
-   * @return The {@link Consumer<Throwable>} uncaught error handler in use
-   */
-  public Consumer<Throwable> getUncaughtErrorHandler() {
-    return uncaughtErrorHandler;
   }
 
   @Override

--- a/reactor-bus/src/main/java/reactor/bus/EventBus.java
+++ b/reactor-bus/src/main/java/reactor/bus/EventBus.java
@@ -35,7 +35,6 @@ import reactor.bus.registry.Registration;
 import reactor.bus.registry.Registries;
 import reactor.bus.registry.Registry;
 import reactor.bus.routing.Router;
-import reactor.bus.selector.ClassSelector;
 import reactor.bus.selector.Selector;
 import reactor.bus.selector.Selectors;
 import reactor.bus.spec.EventBusSpec;
@@ -153,20 +152,18 @@ public class EventBus extends AbstractBus<Object, Event<?>> implements Consumer<
 	public EventBus(@Nullable Processor<Event<?>, Event<?>> processor,
 	                int concurrency,
 	                @Nullable Router router) {
-		this(processor, concurrency, router, null, null);
+		this(processor, concurrency, router, null);
 	}
 
 	public EventBus(@Nullable Processor<Event<?>, Event<?>> processor,
 	                int concurrency,
 	                @Nullable Router router,
-	                @Nullable Consumer<Throwable> processorErrorHandler,
-	                @Nullable final Consumer<Throwable> uncaughtErrorHandler) {
+	                @Nullable Consumer<Throwable> processorErrorHandler) {
 		this(Registries.<Object, BiConsumer<Object, ? extends Event<?>>>create(),
 		  processor,
 		  concurrency,
 		  router,
-		  processorErrorHandler,
-		  uncaughtErrorHandler);
+		  processorErrorHandler);
 	}
 
 	/**
@@ -188,21 +185,17 @@ public class EventBus extends AbstractBus<Object, Event<?>> implements Consumer<
 	 *                              conversion will be used.
 	 * @param processorErrorHandler The {@link Consumer} to be used on {@link Processor} exceptions. May be {@code null}
 	 *                              in which case exceptions will be routed to this {@link EventBus} by it's class.
-	 * @param uncaughtErrorHandler  Default {@link Consumer} to be used on all uncaught exceptions. May be {@code null}
-	 *                              in which case exceptions will be logged.
 	 */
 	@SuppressWarnings("unchecked")
 	public EventBus(@Nonnull final Registry<Object, BiConsumer<Object, ? extends Event<?>>> consumerRegistry,
 	                @Nullable Processor<Event<?>, Event<?>> processor,
 	                int concurrency,
 	                @Nullable final Router router,
-					@Nullable Consumer<Throwable> processorErrorHandler,
-	                @Nullable final Consumer<Throwable> uncaughtErrorHandler) {
+					@Nullable Consumer<Throwable> processorErrorHandler) {
 		super(consumerRegistry,
 					concurrency,
 					router,
-					processorErrorHandler != null ? processorErrorHandler : new UncaughtExceptionConsumer(consumerRegistry),
-					uncaughtErrorHandler);
+					processorErrorHandler != null ? processorErrorHandler : new UncaughtExceptionConsumer(consumerRegistry));
 
 		Assert.notNull(consumerRegistry, "Consumer Registry cannot be null.");
 		this.processor = processor;
@@ -213,8 +206,6 @@ public class EventBus extends AbstractBus<Object, Event<?>> implements Consumer<
 			}
 			processor.onSubscribe(SignalType.NOOP_SUBSCRIPTION);
 		}
-
-		this.on(new ClassSelector(Throwable.class), new BusErrorConsumer(uncaughtErrorHandler));
 	}
 
 	/**
@@ -592,26 +583,6 @@ public class EventBus extends AbstractBus<Object, Event<?>> implements Consumer<
 									   consumerRegistry.select(type),
 									   null,
 									   null);
-		}
-	}
-
-	private static class BusErrorConsumer implements Consumer<Event<Throwable>> {
-
-		final         Logger              log;
-		private final Consumer<Throwable> uncaughtErrorHandler;
-
-		public BusErrorConsumer(Consumer<Throwable> uncaughtErrorHandler) {
-			this.uncaughtErrorHandler = uncaughtErrorHandler;
-			log = Logger.getLogger(EventBus.class);
-		}
-
-		@Override
-		public void accept(Event<Throwable> ev) {
-			if (null == uncaughtErrorHandler) {
-				log.error(ev.getData().getMessage(), ev.getData());
-			} else {
-				uncaughtErrorHandler.accept(ev.getData());
-			}
 		}
 	}
 

--- a/reactor-bus/src/main/java/reactor/bus/spec/EventRoutingComponentSpec.java
+++ b/reactor-bus/src/main/java/reactor/bus/spec/EventRoutingComponentSpec.java
@@ -47,7 +47,6 @@ public abstract class EventRoutingComponentSpec<SPEC extends EventRoutingCompone
 	private Router                                                   router;
 	private Filter                                                   eventFilter;
 	private Consumer<Throwable>                                      dispatchErrorHandler;
-	private Consumer<Throwable>                                      uncaughtErrorHandler;
 	private Registry<Object, BiConsumer<Object, ? extends Event<?>>> consumerRegistry;
 	private boolean traceEventPath = false;
 
@@ -132,19 +131,6 @@ public abstract class EventRoutingComponentSpec<SPEC extends EventRoutingCompone
 	}
 
 	/**
-	 * Configures the component's uncaught error handler for any errors that get reported into this component but
-	 * aren't a
-	 * direct result of dispatching (e.g. errors that originate from another component).
-	 *
-	 * @param uncaughtErrorHandler the error handler for uncaught errors
-	 * @return {@code this}
-	 */
-	public SPEC uncaughtErrorHandler(Consumer<Throwable> uncaughtErrorHandler) {
-		this.uncaughtErrorHandler = uncaughtErrorHandler;
-		return (SPEC) this;
-	}
-
-	/**
 	 * Configures this component to provide event tracing when dispatching and routing an event.
 	 *
 	 * @return {@code this}
@@ -203,8 +189,7 @@ public abstract class EventRoutingComponentSpec<SPEC extends EventRoutingCompone
 		  processor,
 		  concurrency,
 		  (router != null ? router : createEventRouter()),
-		  dispatchErrorHandler,
-		  uncaughtErrorHandler);
+		  dispatchErrorHandler);
 	}
 
 	private Router createEventRouter() {

--- a/reactor-bus/src/test/groovy/reactor/bus/EventBusSpec.groovy
+++ b/reactor-bus/src/test/groovy/reactor/bus/EventBusSpec.groovy
@@ -359,7 +359,6 @@ class EventBusSpec extends Specification {
 	def r = EventBus.config().
 			sync().
 			dispatchErrorHandler(consumer { t -> count++ }).
-			uncaughtErrorHandler(consumer { t -> count++ }).
 			get()
 	r.on $('test'), consumer { ev -> throw new Exception("error") }
 

--- a/reactor-pipe/src/main/java/reactor/pipe/RawBus.java
+++ b/reactor-pipe/src/main/java/reactor/pipe/RawBus.java
@@ -26,13 +26,11 @@ public class RawBus<K, V> extends AbstractBus<K, V> {
                   @Nullable Processor<Runnable, Runnable> processor,
                   int concurrency,
                   @Nullable final Router router,
-                  @Nullable Consumer<Throwable> processorErrorHandler,
-                  @Nullable final Consumer<Throwable> uncaughtErrorHandler) {
+                  @Nullable Consumer<Throwable> processorErrorHandler) {
         super(consumerRegistry,
               concurrency,
               router,
-              processorErrorHandler,
-              uncaughtErrorHandler);
+              processorErrorHandler);
         this.processor = processor;
         this.inDispatcherContext = new ThreadLocal<>();
         this.firehoseSubscription = new FirehoseSubscription();
@@ -44,8 +42,7 @@ public class RawBus<K, V> extends AbstractBus<K, V> {
                                                               public void accept(Runnable runnable, SubscriptionWithContext<Void> voidSubscriptionWithContext) {
                                                                   runnable.run();
                                                               }
-                                                          },
-                                                          uncaughtErrorHandler));
+                                                          }));
             }
             processor.onSubscribe(firehoseSubscription);
         }


### PR DESCRIPTION
An attempt to simplify logging for Bus.

Bus might work with just one logger: 
  * The user would like to attach their own error handler (possibly logger)
  * EventBus would provide an interface that will make thrown events accessible via `on`

Default (`AbstractBus` implementation of Bus) provides the sane default that falls back to  the internal logger.

Providing both and naming them `uncaught` and `processing` error handler has caused many questions at least for us internally. I've had to figure out which one is for and what's hierarchy as well.. 

This way we might simplify and make it a tiny bit more user friendly :)