### PR TITLE
Groovy String interpolation requires double quotes

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,19 +39,19 @@ Snapshot Maven artifacts are provided in the SpringSource snapshot repositories.
 
     dependencies {
       // Reactor Core
-      compile 'io.projectreactor:reactor-core:$reactorVersion'
+      compile "io.projectreactor:reactor-core:$reactorVersion"
 
       // Reactor Stream
-      // compile 'io.projectreactor:reactor-stream:$reactorVersion'
+      // compile "io.projectreactor:reactor-stream:$reactorVersion"
 
       // Reactor Spring
-      // compile 'io.projectreactor:reactor-spring:$reactorVersion'
+      // compile "io.projectreactor:reactor-spring:$reactorVersion"
 
        // Reactor Net
-       // compile 'io.projectreactor:reactor-net:$reactorVersion'
+       // compile "io.projectreactor:reactor-net:$reactorVersion"
 
        // Reactor Codecs (Jackson, Kryo...)
-       // compile 'io.projectreactor:reactor-codec:$reactorVersion'
+       // compile "io.projectreactor:reactor-codec:$reactorVersion"
 
        // Netty for Reactor Net (auto detects if in classpath)
        // compile 'io.netty:netty-all:4.0.27.Final'


### PR DESCRIPTION
Fixes #489