### PR TITLE
Null pointers should not be dereferenced

### DIFF
--- a/reactor-core/src/main/java/reactor/core/subscriber/SubscriberFactory.java
+++ b/reactor-core/src/main/java/reactor/core/subscriber/SubscriberFactory.java
@@ -312,7 +312,7 @@ public abstract class SubscriberFactory {
 						public void request(long n) {
 							if (subscriptionWithContext == null && proxyRequest.get() != Long.MIN_VALUE) {
 								BackpressureUtils.addAndGet(proxyRequest, n);
-							} else {
+							} else if (subscriptionWithContext != null) {
 								subscriptionWithContext.request(n);
 							}
 						}


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule squid:S2259 - Null pointers should not be dereferenced
You can find more information about the issue here:
https://dev.eclipse.org/sonar/coding_rules#q=squid:S2259
Please let me know if you have any questions.
Kirill Vlasov