### PR TITLE
Utility classes should not have public constructors

### DIFF
--- a/reactor-core/src/main/java/reactor/Processors.java
+++ b/reactor-core/src/main/java/reactor/Processors.java
@@ -50,6 +50,9 @@ import reactor.fn.Supplier;
  */
 public final class Processors {
 
+	private Processors() {
+	}
+
 	/**
 	 * Default number of processors available to the runtime on init (min 4)
 	 * @see Runtime#availableProcessors()

--- a/reactor-core/src/main/java/reactor/core/error/Exceptions.java
+++ b/reactor-core/src/main/java/reactor/core/error/Exceptions.java
@@ -37,6 +37,9 @@ public final class Exceptions {
 
 	private static final int MAX_DEPTH = 25;
 
+	private Exceptions() {
+	}
+
 	/**
 	 * Adds a {@code Throwable} to a causality-chain of Throwables, as an additional cause (if it does not
 	 * already appear in the chain among the causes).

--- a/reactor-core/src/main/java/reactor/core/error/SpecificationExceptions.java
+++ b/reactor-core/src/main/java/reactor/core/error/SpecificationExceptions.java
@@ -21,6 +21,9 @@ package reactor.core.error;
  */
 public final class SpecificationExceptions {
 
+	private SpecificationExceptions() {
+	}
+
 	public static IllegalStateException spec_2_12_exception() {
 		return new Spec212_DuplicateOnSubscribe();
 	}

--- a/reactor-core/src/main/java/reactor/core/publisher/convert/DependencyUtils.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/convert/DependencyUtils.java
@@ -36,6 +36,9 @@ public final class DependencyUtils {
 	static private final RxJava1Converter           RX_JAVA_1_CONVERTER;
 	static private final RxJava1SingleConverter     RX_JAVA_1_SINGLE_CONVERTER;
 
+	private DependencyUtils() {
+	}
+
 	static {
 		final int RXJAVA_1_OBSERVABLE = 0b000001;
 		final int RXJAVA_1_SINGLE = 0b000010;

--- a/reactor-core/src/main/java/reactor/core/support/ReactiveStateUtils.java
+++ b/reactor-core/src/main/java/reactor/core/support/ReactiveStateUtils.java
@@ -30,6 +30,9 @@ import java.util.WeakHashMap;
  */
 public final class ReactiveStateUtils implements ReactiveState {
 
+	private ReactiveStateUtils() {
+	}
+
 	/**
 	 * Create an empty graph
 	 * @return a Graph

--- a/reactor-core/src/main/java/reactor/core/support/internal/PlatformDependent.java
+++ b/reactor-core/src/main/java/reactor/core/support/internal/PlatformDependent.java
@@ -28,6 +28,9 @@ public class PlatformDependent {
 
 	private static final boolean HAS_UNSAFE = hasUnsafe0();
 
+	private PlatformDependent() {
+	}
+
 	@SuppressWarnings("unchecked")
 	public static <U, W> AtomicReferenceFieldUpdater<U, W> newAtomicReferenceFieldUpdater(
 			Class<U> tclass, String fieldName) {

--- a/reactor-logback/src/main/java/reactor/logback/DurableLogUtility.java
+++ b/reactor-logback/src/main/java/reactor/logback/DurableLogUtility.java
@@ -45,6 +45,9 @@ public class DurableLogUtility {
 
 	private static Options OPTS = new Options();
 
+	private DurableLogUtility() {
+	}
+
 	static {
 		Option path = new Option("p", "path", true, "Base path to a durable log file to interpret");
 		path.setRequired(true);

--- a/reactor-stream/src/main/java/reactor/rx/Promises.java
+++ b/reactor-stream/src/main/java/reactor/rx/Promises.java
@@ -42,6 +42,9 @@ public final class Promises {
 
 	private final static Promise COMPLETE = success(null);
 
+	private Promises() {
+	}
+
 	/**
 	 * Take the next value from a Publisher on subscribe.
 	 *

--- a/reactor-stream/src/main/java/reactor/rx/stream/StreamFuture.java
+++ b/reactor-stream/src/main/java/reactor/rx/stream/StreamFuture.java
@@ -56,6 +56,9 @@ import reactor.rx.Streams;
  */
 public final class StreamFuture<T> {
 
+	private StreamFuture() {
+	}
+
 	/**
 	 *
 	 * @param future

--- a/reactor-stream/src/main/java/reactor/rx/stream/StreamRange.java
+++ b/reactor-stream/src/main/java/reactor/rx/stream/StreamRange.java
@@ -57,6 +57,8 @@ import reactor.rx.Streams;
  */
 public final class StreamRange {
 
+	private StreamRange() {
+	}
 
 	/**
 	 * Create a Range Stream Publisher


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule squid:S1118 - Utility classes should not have public constructors
You can find more information about the issue here:
https://dev.eclipse.org/sonar/coding_rules#q=squid:S1118
Please let me know if you have any questions.
Kirill Vlasov