### PR TITLE
Groovy Ambiguity Fixes

### DIFF
--- a/reactor-stream/src/main/java/reactor/rx/Stream.java
+++ b/reactor-stream/src/main/java/reactor/rx/Stream.java
@@ -2410,16 +2410,17 @@ public abstract class Stream<O> implements Publisher<O>, ReactiveState.Bounded {
 	 *
 	 * @since 2.5
 	 */
-	public final <T2, V> Stream<V> zipWith(final Publisher<? extends T2> publisher) {
-		return new StreamBarrier<O, V>(this) {
+	public final <T2> Stream<Tuple2<O, T2>> zipWith(final Publisher<? extends T2> publisher) {
+		return new StreamBarrier<O, Tuple2<O, T2>>(this) {
 			@Override
 			public String getName() {
 				return "zipWith";
 			}
 
+			@SuppressWarnings("unchecked")
 			@Override
-			public void subscribe(Subscriber<? super V> s) {
-				Publishers.<O, T2, V>zip(source, publisher, IDENTITY_FUNCTION).subscribe(s);
+			public void subscribe(Subscriber<? super Tuple2<O, T2>> s) {
+				Publishers.<O, T2, Tuple2<O, T2>>zip(source, publisher, IDENTITY_FUNCTION).subscribe(s);
 			}
 		};
 	}

--- a/reactor-stream/src/test/groovy/reactor/rx/StreamsSpec.groovy
+++ b/reactor-stream/src/test/groovy/reactor/rx/StreamsSpec.groovy
@@ -689,7 +689,7 @@ class StreamsSpec extends Specification {
 			'source composables to merge, buffer and tap'
 			def source1 = Broadcaster.<Integer> create()
 			def source2 = Broadcaster.<Integer> create()
-			def zippedStream = Streams.zip(source1, source2) { t1, t2 -> println t1; t1 + t2 }.log()
+			def zippedStream = Streams.zip(source1, source2, (BiFunction) { t1, t2 -> println t1; t1 + t2 }).log()
 			def tap = zippedStream.tap()
 
 		when:
@@ -725,7 +725,7 @@ class StreamsSpec extends Specification {
 
 		when:
 			'the sources are zipped'
-			def zippedStream = Streams.zip(odds.log('left'), even.log('right')) { t1, t2 -> [t1, t2] }
+			def zippedStream = Streams.zip(odds.log('left'), even.log('right'), (BiFunction) { t1, t2 -> [t1, t2] })
 			def tap = zippedStream.log().toList()
 			tap.await(3, TimeUnit.SECONDS)
 			println tap.debug()
@@ -737,8 +737,7 @@ class StreamsSpec extends Specification {
 		when:
 			'the sources are zipped in a flat map'
 			zippedStream = odds.log('before-flatmap').flatMap {
-				Streams.zip(Streams.just(it), even) { t1, t2 -> [t1, t2] }
-						.log('second-fm')
+				Streams.zip(Streams.just(it), even, (BiFunction) { t1, t2 -> [t1, t2] }).log('second-fm')
 			}
 			tap = zippedStream.log('after-zip').toList()
 			tap.await(3, TimeUnit.SECONDS)


### PR DESCRIPTION
Previously there were two tests failing because Groovy could not differentiate between two variants of a given method.  This change updates the tests to explicitly declare the types of the closures used
in these tests to ensure that there would be no ambiguity in method selection.