### PR TITLE
Fix OSGi import packages for reactor

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -192,6 +192,7 @@ project('reactor-core') {
       'com.fasterxml.jackson.databind.node;resolution:=optional',
       'com.fasterxml.jackson.databind.type;resolution:=optional',
       'org.slf4j;version="[1.5.4,2)"',
+      '!reactor.jarjar.*',
       '*'
   ]
 


### PR DESCRIPTION
The MANIFEST.MF contains Import-Package declarations for
“reactor.jarjar” which can’t be resolved. So these are being excluded
now and the ClassLoader will satisfy those from the bundle itself.

FIXES #619