### PR TITLE
Aluminium snapshot reflect no new addon, 3.0.7 core released

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,8 +1,8 @@
-reactorTestVersion=3.0.7.BUILD-SNAPSHOT
+reactorTestVersion=3.0.6.RELEASE
 version=Aluminium-BUILD-SNAPSHOT
-reactorCoreVersion=3.0.7.BUILD-SNAPSHOT
-reactorAdapterVersion=3.0.7.BUILD-SNAPSHOT
+reactorCoreVersion=3.0.7.RELEASE
+reactorAdapterVersion=3.0.6.RELEASE
 reactorNettyVersion=0.6.3.BUILD-SNAPSHOT
 reactorIpcVersion=0.6.2.BUILD-SNAPSHOT
 reactorKafkaVersion=1.0.0.BUILD-SNAPSHOT
-reactorLogbackVersion=3.0.7.BUILD-SNAPSHOT
+reactorLogbackVersion=3.0.6.RELEASE


### PR DESCRIPTION
I was planning on saying on the site that core is only currently part of `Aluminium-SNAPSHOT`.