### PR TITLE
[Obvious Fix] Update README.md : fix documentation link

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,7 +95,7 @@ So far, the release trains are named:
 
 ### Documentation
 
-* [Guides](http://projectreactor.io/docs/)
+* [Guides](http://projectreactor.io/docs)
 * [Reactive Streams](http://www.reactive-streams.org/)
 
 ### Community / Support


### PR DESCRIPTION
Curent link in README.md doesn't work