### PR TITLE
Conditionnally add mavenLocal when releaser script is applied

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -20,6 +20,8 @@ plugins {
 	id "com.jfrog.artifactory" version '4.9.8'
 }
 
+apply from: "gradle/releaser.gradle"
+
 group = 'io.projectreactor'
 description = 'Bill of materials to make sure a consistent set of versions is used for Reactor 3.'
 
@@ -32,12 +34,6 @@ repositories {
 	if (version.endsWith('BUILD-SNAPSHOT')) {
 		mavenLocal()
 		maven { url 'https://repo.spring.io/libs-snapshot' }
-	}
-}
-
-task groupId(group: "releaser helpers", description: "output the group id of the root project") {
-	doLast {
-		println rootProject.group
 	}
 }
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,8 +1,8 @@
 version=Dysprosium-BUILD-SNAPSHOT
 reactorCoreVersion=3.3.1.BUILD-SNAPSHOT
 reactorAddonsVersion=3.3.1.BUILD-SNAPSHOT
+reactorPoolVersion=0.1.1.BUILD-SNAPSHOT
 reactorNettyVersion=0.9.2.BUILD-SNAPSHOT
 reactorKafkaVersion=1.2.1.BUILD-SNAPSHOT
 reactorRabbitVersion=1.3.1.BUILD-SNAPSHOT
-reactorPoolVersion=0.1.1.BUILD-SNAPSHOT
 reactorKotlinExtensionsVersion=1.0.1.BUILD-SNAPSHOT

--- a/gradle/releaser.gradle
+++ b/gradle/releaser.gradle
@@ -1,0 +1,30 @@
+/*
+ * Copyright (c) 2011-2019 Pivotal Software Inc, All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+
+if (project.hasProperty("releaserDryRun") && project.findProperty("releaserDryRun") != "false") {
+	println "Adding MavenLocal() for benefit of releaser dry run"
+	project.repositories {
+		mavenLocal()
+	}
+}
+
+//NOTE: this task is intended for single project builds with no submodules
+task groupId(group: "releaser helpers", description: "output the group id of the root project") {
+	doLast {
+		println rootProject.group
+	}
+}


### PR DESCRIPTION
This is only activated when passing a non-false `-PreleaserDryRun` to Gradle.