### PR TITLE
GitHub Actions Release Process

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,105 @@
+name: publish
+on:
+  push:
+    branches: # For branches, better to list them explicitly than regexp include
+      - master
+      - Dysprosium
+jobs:
+  # General job notes: we DON'T want to cancel any previous runs, especially in the case of a "back to snapshots" build right after a release push
+  # We specify the ubuntu version to minimize the chances we have to deal with a migration during a release
+  prepare:
+    # Notes on prepare: this job has no access to secrets, only github token. As a result, all non-core actions are centralized here
+    # This includes the tagging and drafting of release notes. Still, when possible we favor plain run of gradle tasks
+    name: prepare
+    runs-on: ubuntu-20.04
+    outputs:
+      versionType: ${{ steps.version.outputs.versionType }}
+    steps:
+      - uses: actions/checkout@v2
+      - name: setup java
+        uses: actions/setup-java@v1
+        with:
+          java-version: 8
+      - name: interpret version
+        id: version
+        #we only run the qualifyVersionGha task so that no other console printing can hijack this step's output
+        #output: versionType, fullVersion
+        #fails if versionType is BAD, which interrupts the workflow
+        run: ./gradlew qualifyVersionGha
+      - name: run checks
+        id: checks
+        run: ./gradlew check
+      - name: tag
+        if: steps.version.outputs.versionType == 'RELEASE' || steps.version.outputs.versionType == 'MILESTONE'
+        #specifics: no v prefix for the tag
+        run: |
+          git config --local user.name 'reactorbot'
+          git config --local user.email '32325210+reactorbot@users.noreply.github.com'
+          git tag -m "Release BOM ${{ steps.version.outputs.fullVersion }}" ${{ steps.version.outputs.fullVersion }} ${{ github.sha }}
+          git push --tags
+
+  #deploy the snapshot artifacts to Artifactory
+  deploySnapshot:
+    name: deploySnapshot
+    runs-on: ubuntu-20.04
+    needs: prepare
+    if: needs.prepare.outputs.versionType == 'SNAPSHOT'
+    environment: snapshots
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-java@v1
+        with:
+          java-version: 8
+      - name: deploy
+        env:
+          ORG_GRADLE_PROJECT_artifactory_publish_username: ${{secrets.ARTIFACTORY_SNAPSHOT_USERNAME}}
+          ORG_GRADLE_PROJECT_artifactory_publish_password: ${{secrets.ARTIFACTORY_PASSWORD}}
+        run: |
+          ./gradlew assemble artifactoryPublish -Partifactory_publish_contextUrl=https://repo.spring.io -Partifactory_publish_repoKey=libs-snapshot-local
+
+  #sign the milestone artifacts and deploy them to Artifactory
+  deployMilestone:
+    name: deployMilestone
+    runs-on: ubuntu-20.04
+    needs: prepare
+    if: needs.prepare.outputs.versionType == 'MILESTONE'
+    environment: releases
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-java@v1
+        with:
+          java-version: 8
+      - name: deploy
+        env:
+          ORG_GRADLE_PROJECT_artifactory_publish_username: ${{secrets.ARTIFACTORY_USERNAME}}
+          ORG_GRADLE_PROJECT_artifactory_publish_password: ${{secrets.ARTIFACTORY_PASSWORD}}
+          ORG_GRADLE_PROJECT_signingKey: ${{secrets.SIGNING_KEY}}
+          ORG_GRADLE_PROJECT_signingPassword: ${{secrets.SIGNING_PASSPHRASE}}
+        run: |
+          ./gradlew assemble sign artifactoryPublish -Partifactory_publish_contextUrl=https://repo.spring.io -Partifactory_publish_repoKey=libs-milestone-local
+
+  #sign the release artifacts and deploy them to Artifactory
+  deployRelease:
+    name: deployRelease
+    runs-on: ubuntu-20.04
+    needs: prepare
+    if: needs.prepare.outputs.versionType == 'RELEASE'
+    environment: releases
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-java@v1
+        with:
+          java-version: 8
+      - name: deploy
+        env:
+          ORG_GRADLE_PROJECT_artifactory_publish_username: ${{secrets.ARTIFACTORY_USERNAME}}
+          ORG_GRADLE_PROJECT_artifactory_publish_password: ${{secrets.ARTIFACTORY_PASSWORD}}
+          ORG_GRADLE_PROJECT_signingKey: ${{secrets.SIGNING_KEY}}
+          ORG_GRADLE_PROJECT_signingPassword: ${{secrets.SIGNING_PASSPHRASE}}
+          ORG_GRADLE_PROJECT_sonatypeUsername: ${{secrets.SONATYPE_USERNAME}}
+          ORG_GRADLE_PROJECT_sonatypePassword: ${{secrets.SONATYPE_PASSWORD}}
+        run: |
+          ./gradlew assemble sign artifactoryPublish -Partifactory_publish_contextUrl=https://repo.spring.io  -Partifactory_publish_repoKey=libs-release-local publishMavenJavaPublicationToSonatypeRepository
+
+# For Gradle configuration of signing, see https://docs.gradle.org/current/userguide/signing_plugin.html#sec:in-memory-keys
+# publishMavenJavaPublicationToSonatypeRepository only sends to a staging repository

--- a/build.gradle
+++ b/build.gradle
@@ -14,10 +14,12 @@
  * limitations under the License.
  */
 
+import org.gradle.util.VersionNumber
+
 plugins {
 	id "java-platform"
 	id "maven-publish"
-	id "com.jfrog.artifactory" version '4.9.8'
+	id "com.jfrog.artifactory" version "4.15.2" apply false //we apply the plugin conditionally below
 }
 
 apply from: "gradle/releaser.gradle"
@@ -59,7 +61,61 @@ dependencies {
 	}
 }
 
+
+static def qualifyVersion(String v) {
+	v = v.toUpperCase()
+	if (v.startsWith("DYSPROSIUM")) {
+		//old scheme
+		def qualifier = v.replaceFirst("DYSPROSIUM-", "")
+		if (qualifier == 'RELEASE') return "RELEASE"
+		if (qualifier.matches("(?:SR)\\d+")) return "RELEASE" //old SR
+		if (qualifier.matches("(?:M|RC)\\d+")) return "MILESTONE"
+		if (qualifier == "BUILD-SNAPSHOT") return "SNAPSHOT"
+
+		return "BAD"
+	}
+	//new scheme
+	def versionNumber = VersionNumber.parse(v)
+	if (versionNumber == VersionNumber.UNKNOWN) return "BAD";
+
+	if (versionNumber.qualifier == null || versionNumber.qualifier.size() == 0) return "RELEASE" //new scheme
+	if (versionNumber.qualifier.matches("(?:M|RC)\\d+")) return "MILESTONE"
+	if (versionNumber.qualifier == "SNAPSHOT") return "SNAPSHOT"
+
+	return "BAD"
+}
+
+task qualifyVersionGha() {
+	doLast {
+		def versionType = qualifyVersion("$version")
+
+		println "::set-output name=versionType::$versionType"
+		println "::set-output name=fullVersion::$version"
+		if (versionType == "BAD") {
+			println "::error ::Unable to parse $version to a VersionNumber with recognizable qualifier"
+			throw new TaskExecutionException(tasks.getByName("qualifyVersionGha"), new IllegalArgumentException("Unable to parse $version to a VersionNumber with recognizable qualifier"))
+		}
+	}
+}
+
 publishing {
+	repositories {
+		maven {
+			name = "mock"
+			url = "${rootProject.buildDir}/mockRepo"
+		}
+		if (qualifyVersion("$version") == "RELEASE") {
+			maven {
+				name = "sonatype"
+				url = "https://s01.oss.sonatype.org/service/local/staging/deploy/maven2"
+				credentials {
+					username findProperty("sonatypeUsername")
+					password findProperty("sonatypePassword")
+				}
+			}
+		}
+	}
+
 	publications {
 		mavenJava(MavenPublication) {
 			artifactId = 'reactor-bom'
@@ -137,8 +193,27 @@ publishing {
 	}
 }
 
-artifactoryPublish {
-	//don't activate the onlyIf clause below yet, so that Bamboo builds will publish stuff...
-	//onlyIf { project.hasProperty("artifactory_publish_password") }
-	publications(publishing.publications.mavenJava)
+if (rootProject.hasProperty("artifactory_publish_password")) {
+	apply plugin: "com.jfrog.artifactory"
+
+	artifactoryPublish {
+		publications(publishing.publications.mavenJava)
+	}
+}
+
+if (qualifyVersion("$version") in ["RELEASE", "MILESTONE"] || rootProject.hasProperty("forceSigning")) {
+	apply plugin: 'signing'
+
+	signing {
+		//requiring signature if there is a publish task that is not to MavenLocal
+		required {  gradle.taskGraph.allTasks.any { it.name.toLowerCase().contains("publish")	&& !it.name.contains("MavenLocal") } }
+		def signingKey = findProperty("signingKey")
+		def signingPassword = findProperty("signingPassword")
+
+		useInMemoryPgpKeys(signingKey, signingPassword)
+
+		afterEvaluate {
+			sign publishing.publications.mavenJava
+		}
+	}
 }

--- a/gradle/releaser.gradle
+++ b/gradle/releaser.gradle
@@ -1,7 +1,3 @@
-import java.time.ZoneOffset
-import java.time.ZonedDateTime
-import java.time.temporal.ChronoField
-
 /*
  * Copyright (c) 2011-2019 Pivotal Software Inc, All Rights Reserved.
  *
@@ -18,6 +14,9 @@ import java.time.temporal.ChronoField
  * limitations under the License.
  */
 
+import java.time.ZoneOffset
+import java.time.ZonedDateTime
+import java.time.temporal.ChronoField
 
 if (project.hasProperty("releaserDryRun") && project.findProperty("releaserDryRun") != "false") {
 	println "Adding MavenLocal() for benefit of releaser dry run"
@@ -63,9 +62,9 @@ String getOrGenerateBuildNumber() {
 	if (project.hasProperty("buildNumber")) {
 		return project.findProperty("buildNumber")
 	}
-	def jenkinsNumber = System.getenv("BUILD_NUMBER")
-	if (jenkinsNumber != null) {
-		return jenkinsNumber
+	def ciNumber = System.getenv("GITHUB_RUN_NUMBER")
+	if (ciNumber != null) {
+		return ciNumber
 	}
 	ZonedDateTime now = ZonedDateTime.now(ZoneOffset.UTC)
 	long secondsInDay = now.toEpochSecond() - ZonedDateTime.now(ZoneOffset.UTC).withSecond(0).withHour(0).withMinute(0).toEpochSecond()
@@ -94,8 +93,12 @@ if (project.hasProperty("artifactory_publish_password")) {
 				}
 			}
 			clientConfig.setIncludeEnvVars(false)
-			clientConfig.info.setBuildName('Reactor - Releaser - BOM')
+			clientConfig.info.setBuildName('Reactor - BOM')
 			clientConfig.info.setBuildNumber(buildNumber)
+			if (System.getenv("GITHUB_ACTIONS") == "true") {
+				clientConfig.info.setBuildUrl(System.getenv("GITHUB_SERVER_URL") + "/" + System.getenv("GITHUB_REPOSITORY") + "/actions/runs/" + System.getenv("GITHUB_RUN_ID"))
+				clientConfig.info.setVcsRevision(System.getenv("GITHUB_SHA"))
+			}
 		}
 	}
 }


### PR DESCRIPTION
This commit changes the release process to be based on GitHub Actions.

No CI is currently running for the BOM.

We define helper tasks and methods in the setup.gradle file to help
interpret the version number. The trigger is pushing a commit to an
active maintenance branch.

The new workflow uses GitHub Environments to manage access to secrets,
especially in the case of milestones and releases as it introduces
signing of artifacts in these cases. It is split into 4 jobs, 3 of
which are conditional and depend on a GitHub Environment.

Notably:
 - Add a function to qualify a BOM version as one of RELEASE,
 MILESTONE, SNAPSHOT or BAD. Recognizes `Dysprosium` as old scheme.
 - Add a GitHub Actions oriented task, `qualifyVersionGha`, which
 produces gha step output for the current project version. `versionType`
 is an application of the above function and `fullVersion` is the plain
 project's `version`
 - tag releases and milestones using `git` commands in `prepare` job, without
 a `v` prefix (this is the BOM)
 - Activate the JFrog Artifactory plugin only if a password is defined
 (including in subprojects)
 - Add the `signing` plugin, activated only if a signing key is defined,
   requiring that signing be performed if a publish task is invoked
 - Add a Maven publication repository if Sonatype OSS credentials are
   defined
 - Add a `mock` maven repository target and a `-PforceSigning` option
 for debugging purposes
 - Use the GHA RUN_NUMBER as the build id in Artifactory

See reactor/reactor#694.
See reactor/reactor-addons#254.
