### PR TITLE
[chores] Copyright switch Pivotal to VMware, polish headers

### DIFF
--- a/README.md
+++ b/README.md
@@ -178,4 +178,4 @@ You should then be able to import a `BUILD-SNAPSHOT` version of the BOM, like `D
 # Reactive Streams Commons
 In a continuous mission to design the most efficient concurrency operators for Reactive Streams, a common effort -codename [Reactive Streams Commons](https://github.com/reactor/reactive-streams-commons)- has begun. Reactor is fully aligned with _RSC_ design and is directly inlining _RSC_ within its stable API contract scoped under reactor-core. Reactive Streams Commons is a research effort shared with everyone and is demanding of efficient stream processing challengers, therefore it is naturally decoupled of any framework noise.
 
-_Sponsored by [Pivotal](https://pivotal.io)_
+_Sponsored by [VMware](https://tanzu.vmware.com)_

--- a/build.gradle
+++ b/build.gradle
@@ -1,11 +1,11 @@
 /*
- * Copyright (c) 2011-2017 Pivotal Software Inc, All Rights Reserved.
+ * Copyright (c) 2011-2021 VMware Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *       https://www.apache.org/licenses/LICENSE-2.0
+ *   https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -136,8 +136,8 @@ publishing {
 				}
 				url = 'https://projectreactor.io'
 				organization {
-					name = 'Pivotal Software, Inc.'
-					url = 'https://pivotal.io/'
+					name = 'reactor'
+					url = 'https://github.com/reactor'
 				}
 				licenses {
 					license {
@@ -157,29 +157,19 @@ publishing {
 				}
 				developers {
 					developer {
-						id = 'smaldini'
-						name = 'Stephane Maldini'
-						email = 'smaldini at pivotal.io'
-					}
-					developer {
 						id = 'simonbasle'
 						name = 'Simon Baslé'
-						email = 'sbasle at pivotal.io'
+						email = 'sbasle at vmware.com'
 					}
 					developer {
 						id = 'violetagg'
 						name = 'Violeta Georgieva'
-						email = 'vgeorgieva at pivotal.io'
+						email = 'violetag at vmware.com'
 					}
 					developer {
-						id = 'bsideup'
-						name = 'Sergei Egorov'
-						email = 'segorov at pivotal.io'
-					}
-					developer {
-						id = 'akarnokd'
-						name = 'David Karnok'
-						email = 'akarnokd at gmail.com'
+						id = 'odokuka'
+						name = 'Oleh Dokuka'
+						email = 'odokuka at vmware.com'
 					}
 				}
 				// remove scope information from published BOM

--- a/gradle/releaser.gradle
+++ b/gradle/releaser.gradle
@@ -1,11 +1,11 @@
 /*
- * Copyright (c) 2011-2019 Pivotal Software Inc, All Rights Reserved.
+ * Copyright (c) 2011-2021 VMware Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *       https://www.apache.org/licenses/LICENSE-2.0
+ *   https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,11 +1,11 @@
 /*
- * Copyright (c) 2011-2016 Pivotal Software Inc, All Rights Reserved.
+ * Copyright (c) 2011-2021 VMware Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *       https://www.apache.org/licenses/LICENSE-2.0
+ *   https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -13,4 +13,5 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 rootProject.name = "reactor-bom"


### PR DESCRIPTION
 - copyright header to VMware instead of Pivotal
 - in copyright headers, have date range end on 2021
 - polish copyright header: url indentation, blank line after license
 - fix pom: update developer list (and emails), update organization
 - remove remaining occurrences of Pivotal (eg. in README)

See reactor/reactor#682.
