### PR TITLE
Start of branch 2020.0.x, adapt CI and build

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,8 +1,9 @@
 name: publish
 on:
   push:
-    branches: # For branches, better to list them explicitly than regexp include
+    branches: # For branches, better to list them explicitly than include via glob pattern
       - main
+      - 2020.0.x
       - Dysprosium
 jobs:
   # General job notes: we DON'T want to cancel any previous runs, especially in the case of a "back to snapshots" build right after a release push


### PR DESCRIPTION
Note the `2020.0.x` is a literal match and not a glob pattern (`.` is
a literal, unlike in regular expressions).
