### PR TITLE
Start 2022.0 snapshots BOM, remove kafka/rabbitmq from BOM

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,9 +1,7 @@
-version=2020.0.17-SNAPSHOT
+version=2022.0.0-SNAPSHOT
 
-reactorCoreVersion=3.4.16-SNAPSHOT
-reactorPoolVersion=0.2.8-SNAPSHOT
-reactorNettyVersion=1.0.17-SNAPSHOT
-reactorAddonsVersion=3.4.7-SNAPSHOT
-reactorRabbitVersion=1.5.5-SNAPSHOT
-reactorKafkaVersion=1.3.11-SNAPSHOT
-reactorKotlinExtensionsVersion=1.1.6-SNAPSHOT
+reactorCoreVersion=3.5.0-SNAPSHOT
+reactorPoolVersion=1.0.0-SNAPSHOT
+reactorNettyVersion=1.1.0-SNAPSHOT
+reactorAddonsVersion=3.5.0-SNAPSHOT
+reactorKotlinExtensionsVersion=1.2.0-SNAPSHOT


### PR DESCRIPTION
This commit represents the first BOM of 2022.0 snapshots.
Most notably, reactor-kafka and reactor-rabbitmq have been removed
from the BOM as these projects will either have their own out-of-band
release cycle in 2022, or further than that they'll move out of the
reactor org.
