### PR TITLE
Extract Reactive-Streams version and upgrade to 1.0.4

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2021 VMware Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2011-2022 VMware Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -47,7 +47,7 @@ repositories {
 dependencies {
 	constraints {
 		// Reactive Streams
-		api "org.reactivestreams:reactive-streams:1.0.3"
+		api "org.reactivestreams:reactive-streams:$reactiveStreamsVersion"
 		// Reactor Core
 		api "io.projectreactor:reactor-core:$reactorCoreVersion"
 		// Reactor Addons

--- a/gradle.properties
+++ b/gradle.properties
@@ -8,4 +8,4 @@ reactorRabbitVersion=1.5.6-SNAPSHOT
 reactorKafkaVersion=1.3.12-SNAPSHOT
 reactorKotlinExtensionsVersion=1.1.7-SNAPSHOT
 
-reactiveStreamsVersion=1.0.3
+reactiveStreamsVersion=1.0.4

--- a/gradle.properties
+++ b/gradle.properties
@@ -7,3 +7,5 @@ reactorAddonsVersion=3.4.9-SNAPSHOT
 reactorRabbitVersion=1.5.6-SNAPSHOT
 reactorKafkaVersion=1.3.12-SNAPSHOT
 reactorKotlinExtensionsVersion=1.1.7-SNAPSHOT
+
+reactiveStreamsVersion=1.0.3


### PR DESCRIPTION
This PR extracts the version number of Reactive-Streams dependency into the
gradle.properties file.

Since there was a recent release of the library following a relicensing and
including TCK improvements, the version is also upgraded to 1.0.4.
This is in alignment with the dependency declared in Reactor-Core itself.