### PR TITLE
Reintegrate Reactor-Kafka in BOM, using 1.3.x common line

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -69,6 +69,8 @@ dependencies {
 		api "io.projectreactor.addons:reactor-pool:$reactorPoolVersion"
 		//Reactor Kotlin Extensions
 		api "io.projectreactor.kotlin:reactor-kotlin-extensions:$reactorKotlinExtensionsVersion"
+		//Reactor Kafka should be compatible with both 2020 and 2022 release trains
+		api "io.projectreactor.kafka:reactor-kafka:$reactorKafkaVersion"
 	}
 }
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -7,5 +7,6 @@ reactorNettyVersion=1.1.0-SNAPSHOT
 reactorNetty5Version=2.0.0-M1
 reactorAddonsVersion=3.5.0-SNAPSHOT
 reactorKotlinExtensionsVersion=1.2.0-SNAPSHOT
+reactorKafkaVersion=1.3.12-SNAPSHOT
 
 reactiveStreamsVersion=1.0.4


### PR DESCRIPTION
When discussing the future of Reactor-Kafka, it was requested that the project be reintegrated into the BOM of `2022.0`.

In order to limit the maintenance and release effort for the Reactor team, we'll attempt to use a single common version for both release trains `2020.0` and upcoming `2022.0`.